### PR TITLE
Show the SVG map in full screen

### DIFF
--- a/estatioapp/dom/src/main/java/org/estatio/app/interactivemap/InteractiveMapForFixedAssetService.java
+++ b/estatioapp/dom/src/main/java/org/estatio/app/interactivemap/InteractiveMapForFixedAssetService.java
@@ -27,20 +27,16 @@ import javax.inject.Inject;
 import org.apache.isis.applib.annotation.ActionSemantics;
 import org.apache.isis.applib.annotation.ActionSemantics.Of;
 import org.apache.isis.applib.annotation.DomainService;
-import org.apache.isis.applib.annotation.Named;
-import org.apache.isis.applib.annotation.NotContributed;
 import org.apache.isis.applib.annotation.NotInServiceMenu;
 import org.apache.isis.applib.services.linking.DeepLinkService;
-
-import org.isisaddons.wicket.svg.cpt.applib.InteractiveMap;
-import org.isisaddons.wicket.svg.cpt.applib.InteractiveMapAttribute;
-import org.isisaddons.wicket.svg.cpt.applib.InteractiveMapElement;
-
 import org.estatio.dom.asset.Property;
 import org.estatio.dom.asset.Unit;
 import org.estatio.dom.asset.Units;
 import org.estatio.dom.document.InteractiveMapDocument;
 import org.estatio.dom.document.InteractiveMapDocuments;
+import org.isisaddons.wicket.svg.cpt.applib.InteractiveMap;
+import org.isisaddons.wicket.svg.cpt.applib.InteractiveMapAttribute;
+import org.isisaddons.wicket.svg.cpt.applib.InteractiveMapElement;
 
 @DomainService
 public class InteractiveMapForFixedAssetService {
@@ -99,6 +95,11 @@ public class InteractiveMapForFixedAssetService {
 
     public List<InteractiveMapDocument> choices0ShowMap() {
         return documents.allDocuments();
+    }
+
+    public boolean hideShowMap(Property property, InteractiveMapForFixedAssetRepresentation representation) {
+        InteractiveMapDocument document = documents.findByFixedAsset(property);
+        return document == null;
     }
 
     // //////////////////////////////////////

--- a/estatioapp/dom/src/main/java/org/estatio/dom/document/InteractiveMapDocument.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/document/InteractiveMapDocument.java
@@ -41,7 +41,7 @@ import org.estatio.dom.asset.FixedAsset;
 @javax.jdo.annotations.Query(
         name = "findByFixedAsset", language = "JDOQL",
         value = "SELECT "
-                + "FROM org.estatio.dom.interactivemap.InteractiveMapDocument "
+                + "FROM org.estatio.dom.document.InteractiveMapDocument "
                 + "WHERE fixedAsset == :fixedAsset")
 @Bookmarkable
 @Named("Document")

--- a/estatioapp/fixture/src/main/resources/svg/OXF.svg
+++ b/estatioapp/fixture/src/main/resources/svg/OXF.svg
@@ -2,7 +2,7 @@
 <!-- Generator: Adobe Illustrator 16.0.3, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="794.737px" height="339.474px" viewBox="0 0 794.737 339.474" enable-background="new 0 0 794.737 339.474"
+	 viewBox="0 0 794.737 339.474" enable-background="new 0 0 794.737 339.474"
 	 xml:space="preserve">
 <g id="color_key_1_">
 	<polygon id="OXF-069" fill="#88BCE7" points="505.038,197.03 517.028,207.62 506.108,218.459 502.858,218.459 502.858,214.04 


### PR DESCRIPTION
Fixes:

- show the map in 100% width and height (depends on the latest version of https://github.com/jcvanderwal/isis-wicket-svg).
- fixed a wrong package name in JDO query.
- do not show the contributed action "Show map" when there is no SVG map for an unit