### PR TITLE
Remove unused objects and make "public static" fields should be constant

### DIFF
--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/BusinessCase.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/BusinessCase.java
@@ -124,7 +124,6 @@ public class BusinessCase extends UdoDomainObject<BusinessCase> implements Chain
 			@ParameterLayout(named = "Next review date")
 			final LocalDate reviewDate){
 		
-		new LocalDate();
 		final LocalDate now = LocalDate.now();
 		
 		BusinessCase nextBusinesscase = businesscases.newBusinessCase(this.getProject(), businessCaseDescription, reviewDate, this.date, now, this.getBusinessCaseVersion() + 1);
@@ -156,7 +155,6 @@ public class BusinessCase extends UdoDomainObject<BusinessCase> implements Chain
 			return "This is no active version of the business case and cannot be updated";
 		}
 		
-		new LocalDate();
 		LocalDate now = LocalDate.now();
 		if (reviewDate.isBefore(now)) {
 			return "A review date should not be in the past";

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/BusinessCaseContributions.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/BusinessCaseContributions.java
@@ -30,7 +30,6 @@ public class BusinessCaseContributions  {
 			final LocalDate reviewDate
 			){
 		
-		new LocalDate();
 		final LocalDate now = LocalDate.now();
 		return businesscases.newBusinessCase(project, businessCaseDescription, reviewDate, now, null, 1);
 	}
@@ -50,7 +49,6 @@ public class BusinessCaseContributions  {
 			return "This project has a business case already; use update business case instead";
 		}
 		
-		new LocalDate();
 		LocalDate now = LocalDate.now();
 		if (reviewDate.isBefore(now)) {
 			return "A review date should not be in the past";

--- a/estatioapp/fixture/src/main/java/org/estatio/fixture/security/tenancy/AbstractApplicationTenancyFixtureScript.java
+++ b/estatioapp/fixture/src/main/java/org/estatio/fixture/security/tenancy/AbstractApplicationTenancyFixtureScript.java
@@ -26,7 +26,7 @@ import org.estatio.dom.valuetypes.ApplicationTenancyLevel;
 
 public abstract class AbstractApplicationTenancyFixtureScript extends FixtureScript {
 
-    static public String ONLY = "_";
+    public static final String ONLY = "_";
 
     protected ApplicationTenancy create(
             final String name,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1848 - “ Objects should not be created to be dropped immediately without being used”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1848
And
squid:S1444 - “"public static" fields should be constant”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1444
Please let me know if you have any questions.
Ayman Abdelghany.
