### PR TITLE
"BigDecimal(double)" should not be used

### DIFF
--- a/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/DistributionService.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/DistributionService.java
@@ -189,7 +189,7 @@ public class DistributionService {
     }
 
     private BigDecimal increment(final int scale) {
-        return new BigDecimal(0.1).pow(scale, MathContext.DECIMAL64);
+        return BigDecimal.valueOf(0.1).pow(scale, MathContext.DECIMAL64);
     }
 
     private class OutputHelper {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/keytable/KeyValueMethod.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/keytable/KeyValueMethod.java
@@ -28,7 +28,7 @@ public enum KeyValueMethod {
     PROMILLE {
         @Override
         public boolean isValid(KeyTable keyTable) {
-                if (!this.keySum(keyTable).equals(new BigDecimal(1000.000).setScale(keyTable.getPrecision(),BigDecimal.ROUND_HALF_UP))) {
+                if (!this.keySum(keyTable).equals(BigDecimal.valueOf(1000.000).setScale(keyTable.getPrecision(),BigDecimal.ROUND_HALF_UP))) {
                     return false;
                 }
             return true;
@@ -49,7 +49,7 @@ public enum KeyValueMethod {
     PERCENT {
         @Override
         public boolean isValid(KeyTable keyTable) {
-            if (!this.keySum(keyTable).equals(new BigDecimal(100.000).setScale(keyTable.getPrecision(), BigDecimal.ROUND_HALF_UP))) {
+            if (!this.keySum(keyTable).equals(BigDecimal.valueOf(100.000).setScale(keyTable.getPrecision(), BigDecimal.ROUND_HALF_UP))) {
                 return false;
             }
             return true;

--- a/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/DistributionServiceTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/DistributionServiceTest.java
@@ -23,18 +23,18 @@ public class DistributionServiceTest {
 
         //10000.99
         KeyItem item1 = new KeyItem();
-        item1.setSourceValue(new BigDecimal(10000.99));
+        item1.setSourceValue(BigDecimal.valueOf(10000.99));
         input.add(item1);
 
         //0.99
         KeyItem item2 = new KeyItem();
-        item2.setSourceValue(new BigDecimal(0.99));
+        item2.setSourceValue(BigDecimal.valueOf(0.99));
         input.add(item2);
 
         //1.99
         for (int i = 2; i < 14; i = i + 1) {
             KeyItem item = new KeyItem();
-            item.setSourceValue(new BigDecimal(1.99));
+            item.setSourceValue(BigDecimal.valueOf(1.99));
             input.add(item);
         }
 
@@ -50,18 +50,18 @@ public class DistributionServiceTest {
 
         //then
         Assertions.assertThat(output.size()).isEqualTo(14);
-        Assertions.assertThat(output.get(0).getValue()).isEqualTo(new BigDecimal(997.519).setScale(3, BigDecimal.ROUND_HALF_UP));
-        Assertions.assertThat(output.get(1).getValue()).isEqualTo(new BigDecimal(0.099).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(0).getValue()).isEqualTo(BigDecimal.valueOf(997.519).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(1).getValue()).isEqualTo(BigDecimal.valueOf(0.099).setScale(3, BigDecimal.ROUND_HALF_UP));
 
         for (int i = 2; i < 8; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.198).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.198).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 8; i < 14; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.199).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.199).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
-        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(new BigDecimal(1000.000).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(BigDecimal.valueOf(1000.000).setScale(3, BigDecimal.ROUND_HALF_UP));
 
     }
 
@@ -74,18 +74,18 @@ public class DistributionServiceTest {
 
         //10000.99
         KeyItem item1 = new KeyItem();
-        item1.setSourceValue(new BigDecimal(10000.99));
+        item1.setSourceValue(BigDecimal.valueOf(10000.99));
         input.add(item1);
 
         //100.01
         KeyItem item2 = new KeyItem();
-        item2.setSourceValue(new BigDecimal(100.01));
+        item2.setSourceValue(BigDecimal.valueOf(100.01));
         input.add(item2);
 
         //1.99
         for (int i = 2; i < 14; i = i + 1) {
             KeyItem item = new KeyItem();
-            item.setSourceValue(new BigDecimal(1.99));
+            item.setSourceValue(BigDecimal.valueOf(1.99));
             input.add(item);
         }
 
@@ -101,18 +101,18 @@ public class DistributionServiceTest {
 
         //then
         Assertions.assertThat(output.size()).isEqualTo(14);
-        Assertions.assertThat(output.get(0).getValue()).isEqualTo(new BigDecimal(987.764).setScale(3, BigDecimal.ROUND_HALF_UP));
-        Assertions.assertThat(output.get(1).getValue()).isEqualTo(new BigDecimal(9.878).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(0).getValue()).isEqualTo(BigDecimal.valueOf(987.764).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(1).getValue()).isEqualTo(BigDecimal.valueOf(9.878).setScale(3, BigDecimal.ROUND_HALF_UP));
 
         for (int i = 2; i < 8; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.197).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.197).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 8; i < 14; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.196).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.196).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
-        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(new BigDecimal(1000.000).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(BigDecimal.valueOf(1000.000).setScale(3, BigDecimal.ROUND_HALF_UP));
 
     }
 
@@ -125,18 +125,18 @@ public class DistributionServiceTest {
 
         //10000.99
         KeyItem item1 = new KeyItem();
-        item1.setSourceValue(new BigDecimal(10000.99));
+        item1.setSourceValue(BigDecimal.valueOf(10000.99));
         input.add(item1);
 
         //200.09
         KeyItem item2 = new KeyItem();
-        item2.setSourceValue(new BigDecimal(200.09));
+        item2.setSourceValue(BigDecimal.valueOf(200.09));
         input.add(item2);
 
         //1.99
         for (int i = 2; i < 14; i = i + 1) {
             KeyItem item = new KeyItem();
-            item.setSourceValue(new BigDecimal(1.99));
+            item.setSourceValue(BigDecimal.valueOf(1.99));
             input.add(item);
         }
 
@@ -152,18 +152,18 @@ public class DistributionServiceTest {
 
         //then
         Assertions.assertThat(output.size()).isEqualTo(14);
-        Assertions.assertThat(output.get(0).getValue()).isEqualTo(new BigDecimal(978.10).setScale(2, BigDecimal.ROUND_HALF_UP));
-        Assertions.assertThat(output.get(1).getValue()).isEqualTo(new BigDecimal(19.57).setScale(2, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(0).getValue()).isEqualTo(BigDecimal.valueOf(978.10).setScale(2, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(1).getValue()).isEqualTo(BigDecimal.valueOf(19.57).setScale(2, BigDecimal.ROUND_HALF_UP));
 
         for (int i = 2; i < 9; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.19).setScale(2, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.19).setScale(2, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 9; i < 14; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.20).setScale(2, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.20).setScale(2, BigDecimal.ROUND_HALF_UP));
         }
 
-        Assertions.assertThat(sumRoundedValues.setScale(2, BigDecimal.ROUND_HALF_UP)).isEqualTo(new BigDecimal(1000.00).setScale(2, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sumRoundedValues.setScale(2, BigDecimal.ROUND_HALF_UP)).isEqualTo(BigDecimal.valueOf(1000.00).setScale(2, BigDecimal.ROUND_HALF_UP));
     }
 
     @Test
@@ -175,18 +175,18 @@ public class DistributionServiceTest {
 
         //10000.99
         KeyItem item1 = new KeyItem();
-        item1.setSourceValue(new BigDecimal(10000.99));
+        item1.setSourceValue(BigDecimal.valueOf(10000.99));
         input.add(item1);
 
         //100.09
         KeyItem item2 = new KeyItem();
-        item2.setSourceValue(new BigDecimal(100.09));
+        item2.setSourceValue(BigDecimal.valueOf(100.09));
         input.add(item2);
 
         //1.99
         for (int i = 2; i < 14; i = i + 1) {
             KeyItem item = new KeyItem();
-            item.setSourceValue(new BigDecimal(1.99));
+            item.setSourceValue(BigDecimal.valueOf(1.99));
             input.add(item);
         }
 
@@ -194,7 +194,7 @@ public class DistributionServiceTest {
         //in this example here we get to + 0.05
 
         //when
-        List<Distributable> output = distributionService.distribute(input, new BigDecimal(1000), 2);
+        List<Distributable> output = distributionService.distribute(input, BigDecimal.valueOf(1000), 2);
         BigDecimal sumRoundedValues = BigDecimal.ZERO;
         for (Distributable object: output) {
             sumRoundedValues = sumRoundedValues.add(object.getValue(), MathContext.DECIMAL32);
@@ -202,18 +202,18 @@ public class DistributionServiceTest {
 
         //then
         Assertions.assertThat(output.size()).isEqualTo(14);
-        Assertions.assertThat(output.get(0).getValue()).isEqualTo(new BigDecimal(987.76).setScale(2, BigDecimal.ROUND_HALF_UP));
-        Assertions.assertThat(output.get(1).getValue()).isEqualTo(new BigDecimal(9.89).setScale(2, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(0).getValue()).isEqualTo(BigDecimal.valueOf(987.76).setScale(2, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(1).getValue()).isEqualTo(BigDecimal.valueOf(9.89).setScale(2, BigDecimal.ROUND_HALF_UP));
 
         for (int i = 2; i < 9; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.20).setScale(2, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.20).setScale(2, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 9; i < 14; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.19).setScale(2, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.19).setScale(2, BigDecimal.ROUND_HALF_UP));
         }
 
-        Assertions.assertThat(sumRoundedValues.setScale(2, BigDecimal.ROUND_HALF_UP)).isEqualTo(new BigDecimal(1000.00).setScale(2, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sumRoundedValues.setScale(2, BigDecimal.ROUND_HALF_UP)).isEqualTo(BigDecimal.valueOf(1000.00).setScale(2, BigDecimal.ROUND_HALF_UP));
 
     }
 
@@ -226,18 +226,18 @@ public class DistributionServiceTest {
 
         //10000.99
         KeyItem item1 = new KeyItem();
-        item1.setSourceValue(new BigDecimal(10000.99));
+        item1.setSourceValue(BigDecimal.valueOf(10000.99));
         input.add(item1);
 
         //0.99
         KeyItem item2 = new KeyItem();
-        item2.setSourceValue(new BigDecimal(0.99));
+        item2.setSourceValue(BigDecimal.valueOf(0.99));
         input.add(item2);
 
         //1.99
         for (int i = 2; i < 14; i = i + 1) {
             KeyItem item = new KeyItem();
-            item.setSourceValue(new BigDecimal(1.99));
+            item.setSourceValue(BigDecimal.valueOf(1.99));
             input.add(item);
         }
 
@@ -254,19 +254,19 @@ public class DistributionServiceTest {
         //then
 
         Assertions.assertThat(output.size()).isEqualTo(14);
-        Assertions.assertThat(output.get(0).getValue()).isEqualTo(new BigDecimal(99.752).setScale(3, BigDecimal.ROUND_HALF_UP));
-        Assertions.assertThat(output.get(1).getValue()).isEqualTo(new BigDecimal(0.010).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(0).getValue()).isEqualTo(BigDecimal.valueOf(99.752).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(1).getValue()).isEqualTo(BigDecimal.valueOf(0.010).setScale(3, BigDecimal.ROUND_HALF_UP));
 
         for (int i = 2; i < 12; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.020).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.020).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 12; i < 14; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.019).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.019).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
         // Corrected Rounding Error for 3 decimals
-        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(new BigDecimal(100.000).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(BigDecimal.valueOf(100.000).setScale(3, BigDecimal.ROUND_HALF_UP));
 
     }
 
@@ -279,18 +279,18 @@ public class DistributionServiceTest {
 
         //10000.99
         KeyItem item1 = new KeyItem();
-        item1.setSourceValue(new BigDecimal(10000.99));
+        item1.setSourceValue(BigDecimal.valueOf(10000.99));
         input.add(item1);
 
         //200.99
         KeyItem item2 = new KeyItem();
-        item2.setSourceValue(new BigDecimal(200.99));
+        item2.setSourceValue(BigDecimal.valueOf(200.99));
         input.add(item2);
 
         //1.99
         for (int i = 2; i < 14; i = i + 1) {
             KeyItem item = new KeyItem();
-            item.setSourceValue(new BigDecimal(1.99));
+            item.setSourceValue(BigDecimal.valueOf(1.99));
             input.add(item);
         }
 
@@ -307,19 +307,19 @@ public class DistributionServiceTest {
         //then
 
         Assertions.assertThat(output.size()).isEqualTo(14);
-        Assertions.assertThat(output.get(0).getValue()).isEqualTo(new BigDecimal(97.801).setScale(3, BigDecimal.ROUND_HALF_UP));
-        Assertions.assertThat(output.get(1).getValue()).isEqualTo(new BigDecimal(1.966).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(0).getValue()).isEqualTo(BigDecimal.valueOf(97.801).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(1).getValue()).isEqualTo(BigDecimal.valueOf(1.966).setScale(3, BigDecimal.ROUND_HALF_UP));
 
         for (int i = 2; i < 9; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.019).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.019).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 9; i < 14; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.020).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.020).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
         // Corrected Rounding Error for 3 decimals
-        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(new BigDecimal(100.000).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(BigDecimal.valueOf(100.000).setScale(3, BigDecimal.ROUND_HALF_UP));
     }
 
     @Test
@@ -382,18 +382,18 @@ public class DistributionServiceTest {
 
         //10000.99 1 item
         KeyItem item1 = new KeyItem();
-        item1.setSourceValue(new BigDecimal(10000.99));
+        item1.setSourceValue(BigDecimal.valueOf(10000.99));
         input.add(item1);
 
         //0.99 1 item
         KeyItem item2 = new KeyItem();
-        item2.setSourceValue(new BigDecimal(0.99));
+        item2.setSourceValue(BigDecimal.valueOf(0.99));
         input.add(item2);
 
         //1.99 10 items
         for (int i = 1; i < 11; i = i + 1) {
             KeyItem item = new KeyItem();
-            item.setSourceValue(new BigDecimal(1.99));
+            item.setSourceValue(BigDecimal.valueOf(1.99));
             input.add(item);
         }
 
@@ -417,35 +417,35 @@ public class DistributionServiceTest {
 
         //then
         Assertions.assertThat(output.size()).isEqualTo(14);
-        Assertions.assertThat(output.get(0).getValue()).isEqualTo(new BigDecimal(997.915561).setScale(6, BigDecimal.ROUND_HALF_UP));
-        Assertions.assertThat(output.get(1).getValue()).isEqualTo(new BigDecimal(0.098784).setScale(6, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(0).getValue()).isEqualTo(BigDecimal.valueOf(997.915561).setScale(6, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(1).getValue()).isEqualTo(BigDecimal.valueOf(0.098784).setScale(6, BigDecimal.ROUND_HALF_UP));
 
         // 5 items not rounded
         for (int i = 2; i < 7; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.198566).setScale(6, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.198566).setScale(6, BigDecimal.ROUND_HALF_UP));
         }
 
         // 5 items rounded down
         for (int i = 7; i < 12; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.198565).setScale(6, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.198565).setScale(6, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 12; i < 13; i = i + 1) {
             Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.ZERO.setScale(6, BigDecimal.ROUND_HALF_UP));
         }
 
-        Assertions.assertThat(sumRoundedValues.setScale(6, BigDecimal.ROUND_HALF_UP)).isEqualTo(new BigDecimal(1000.000000).setScale(6, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sumRoundedValues.setScale(6, BigDecimal.ROUND_HALF_UP)).isEqualTo(BigDecimal.valueOf(1000.000000).setScale(6, BigDecimal.ROUND_HALF_UP));
 
     }
 
     @Test
     public void roundingTest() {
 
-        BigDecimal one = new BigDecimal(86.15385).setScale(5, BigDecimal.ROUND_HALF_UP);
+        BigDecimal one = BigDecimal.valueOf(86.15385).setScale(5, BigDecimal.ROUND_HALF_UP);
         BigDecimal two = new BigDecimal(800).multiply(new BigDecimal(1000), MathContext.DECIMAL64).divide(new BigDecimal(32500), MathContext.DECIMAL64).setScale(5, BigDecimal.ROUND_HALF_UP);
         BigDecimal sum = one.add(two, MathContext.DECIMAL64).setScale(5, BigDecimal.ROUND_HALF_UP);
 
-        Assertions.assertThat(sum).isEqualTo(new BigDecimal(110.76923).setScale(5, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sum).isEqualTo(BigDecimal.valueOf(110.76923).setScale(5, BigDecimal.ROUND_HALF_UP));
 
     }
 
@@ -538,18 +538,18 @@ public class DistributionServiceTest {
 
         //10000.99
         KeyItem item1 = new KeyItem();
-        item1.setSourceValue(new BigDecimal(10000.99));
+        item1.setSourceValue(BigDecimal.valueOf(10000.99));
         input.add(item1);
 
         //0.99
         KeyItem item2 = new KeyItem();
-        item2.setSourceValue(new BigDecimal(0.99));
+        item2.setSourceValue(BigDecimal.valueOf(0.99));
         input.add(item2);
 
         //1.99
         for (int i = 2; i < 11; i = i + 1) {
             KeyItem item = new KeyItem();
-            item.setSourceValue(new BigDecimal(1.99));
+            item.setSourceValue(BigDecimal.valueOf(1.99));
             input.add(item);
         }
 
@@ -572,22 +572,22 @@ public class DistributionServiceTest {
 
         //then
         Assertions.assertThat(output.size()).isEqualTo(14);
-        Assertions.assertThat(output.get(0).getValue()).isEqualTo(new BigDecimal(998.114).setScale(3, BigDecimal.ROUND_HALF_UP));
-        Assertions.assertThat(output.get(1).getValue()).isEqualTo(new BigDecimal(0.099).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(0).getValue()).isEqualTo(BigDecimal.valueOf(998.114).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(output.get(1).getValue()).isEqualTo(BigDecimal.valueOf(0.099).setScale(3, BigDecimal.ROUND_HALF_UP));
 
         for (int i = 2; i < 7; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.199).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.199).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 7; i < 11; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.198).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.198).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
         for (int i = 11; i < 14; i = i + 1) {
-            Assertions.assertThat(output.get(i).getValue()).isEqualTo(new BigDecimal(0.000).setScale(3, BigDecimal.ROUND_HALF_UP));
+            Assertions.assertThat(output.get(i).getValue()).isEqualTo(BigDecimal.valueOf(0.000).setScale(3, BigDecimal.ROUND_HALF_UP));
         }
 
-        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(new BigDecimal(1000.000).setScale(3, BigDecimal.ROUND_HALF_UP));
+        Assertions.assertThat(sumRoundedValues.setScale(3, BigDecimal.ROUND_HALF_UP)).isEqualTo(BigDecimal.valueOf(1000.000).setScale(3, BigDecimal.ROUND_HALF_UP));
 
     }
 

--- a/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/allocation/BudgetItemAllocationTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/allocation/BudgetItemAllocationTest.java
@@ -65,8 +65,8 @@ public class BudgetItemAllocationTest {
             budgetItemAllocation.setPercentage(new BigDecimal(100));
 
             //when then
-            assertThat(budgetItemAllocation.validateUpdatePercentage(new BigDecimal(100.01)), is("percentage should be in range 0 - 100"));
-            assertThat(budgetItemAllocation.validateUpdatePercentage(new BigDecimal(-0.01)), is("percentage should be in range 0 - 100"));
+            assertThat(budgetItemAllocation.validateUpdatePercentage(BigDecimal.valueOf(100.01)), is("percentage should be in range 0 - 100"));
+            assertThat(budgetItemAllocation.validateUpdatePercentage(BigDecimal.valueOf(-0.01)), is("percentage should be in range 0 - 100"));
             assertThat(budgetItemAllocation.validateUpdatePercentage(new BigDecimal(100)), is(nullValue()));
             assertThat(budgetItemAllocation.validateUpdatePercentage(new BigDecimal(0)), is(nullValue()));
         }

--- a/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/budgetitem/BudgetItemTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/budgetitem/BudgetItemTest.java
@@ -58,9 +58,9 @@ public class BudgetItemTest {
         @Test
         public void testValidateChange() {
             final BudgetItem budgetItem = new BudgetItemForTesting();
-            assertThat(budgetItem.validateChangeBudgetedValue(new BigDecimal(-0.01))).isEqualTo("Value should be a positive non zero value");
+            assertThat(budgetItem.validateChangeBudgetedValue(BigDecimal.valueOf(-0.01))).isEqualTo("Value should be a positive non zero value");
             assertThat(budgetItem.validateChangeBudgetedValue(new BigDecimal(0))).isEqualTo("Value should be a positive non zero value");
-            assertThat(budgetItem.validateChangeBudgetedValue(new BigDecimal(0.01))).isEqualTo(null);
+            assertThat(budgetItem.validateChangeBudgetedValue(BigDecimal.valueOf(0.01))).isEqualTo(null);
         }
 
     }
@@ -73,9 +73,9 @@ public class BudgetItemTest {
             final BudgetItem budgetItem = new BudgetItemForTesting();
             final BigDecimal anyValueWillDo = new BigDecimal(10);
             //when
-            budgetItem.setBudgetedValue(new BigDecimal(1000.00));
+            budgetItem.setBudgetedValue(BigDecimal.valueOf(1000.00));
             //then
-            assertThat(budgetItem.default0ChangeBudgetedValue(anyValueWillDo)).isEqualTo(new BigDecimal(1000.00));
+            assertThat(budgetItem.default0ChangeBudgetedValue(anyValueWillDo)).isEqualTo(BigDecimal.valueOf(1000.00));
         }
 
     }
@@ -85,9 +85,9 @@ public class BudgetItemTest {
         @Test
         public void testValidateChange() {
             final BudgetItem budgetItem = new BudgetItemForTesting();
-            assertThat(budgetItem.validateChangeAuditedValue(new BigDecimal(-0.01))).isEqualTo("Value can't be negative");
+            assertThat(budgetItem.validateChangeAuditedValue(BigDecimal.valueOf(-0.01))).isEqualTo("Value can't be negative");
             assertThat(budgetItem.validateChangeAuditedValue(new BigDecimal(0))).isEqualTo(null);
-            assertThat(budgetItem.validateChangeAuditedValue(new BigDecimal(0.01))).isEqualTo(null);
+            assertThat(budgetItem.validateChangeAuditedValue(BigDecimal.valueOf(0.01))).isEqualTo(null);
         }
 
     }

--- a/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/budgetitem/BudgetItemsTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/budgetitem/BudgetItemsTest.java
@@ -141,9 +141,9 @@ public class BudgetItemsTest {
             Charge charge = new ChargeForTesting();
 
             //when
-            BigDecimal negativeValue = new BigDecimal(-0.01);
+            BigDecimal negativeValue = BigDecimal.valueOf(-0.01);
             BigDecimal zeroValue = BigDecimal.ZERO;
-            BigDecimal positiveValue = new BigDecimal(0.01);
+            BigDecimal positiveValue = BigDecimal.valueOf(0.01);
             //then
             assertThat(budgetItemRepository.validateNewBudgetItem(budget,negativeValue,charge), is("Value can't be negative"));
             assertThat(budgetItemRepository.validateNewBudgetItem(budget,zeroValue,charge), is(nullValue()));

--- a/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/keyitem/KeyItemRepositoryTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/keyitem/KeyItemRepositoryTest.java
@@ -62,7 +62,7 @@ public class KeyItemRepositoryTest {
         //given
         KeyTable keyTable = new KeyTableForTesting();
         Unit unit = new UnitForTesting();
-        BigDecimal sourcevalue = new BigDecimal(-0.001);
+        BigDecimal sourcevalue = BigDecimal.valueOf(-0.001);
         BigDecimal keyValue = new BigDecimal(10);
 
         //when
@@ -83,7 +83,7 @@ public class KeyItemRepositoryTest {
         KeyTable keyTable = new KeyTableForTesting();
         Unit unit = new UnitForTesting();
         BigDecimal sourcevalue = new BigDecimal(1);
-        BigDecimal keyValue = new BigDecimal(-0.001);
+        BigDecimal keyValue = BigDecimal.valueOf(-0.001);
 
         //when
         String validateNewBudgetKeyItem = keyItemRepository.validateNewItem(

--- a/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/keyitem/KeyItemTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/keyitem/KeyItemTest.java
@@ -61,11 +61,11 @@ public class KeyItemTest {
         assertTrue(item.getValue().equals(new BigDecimal(2)));
 
         //when
-        item.changeValue(new BigDecimal(2.3335));
+        item.changeValue(BigDecimal.valueOf(2.3335));
 
         //then
-        assertEquals(item.getValue(),new BigDecimal(2.333).setScale(3, BigDecimal.ROUND_HALF_UP));
-        assertFalse(item.getValue().equals(new BigDecimal(2.334).setScale(3, BigDecimal.ROUND_HALF_UP)));
+        assertEquals(item.getValue(),BigDecimal.valueOf(2.333).setScale(3, BigDecimal.ROUND_HALF_UP));
+        assertFalse(item.getValue().equals(BigDecimal.valueOf(2.334).setScale(3, BigDecimal.ROUND_HALF_UP)));
 
     }
 
@@ -81,7 +81,7 @@ public class KeyItemTest {
         assertTrue(item.getValue().equals(new BigDecimal(2)));
 
         //when, then
-        assertEquals(item.validateChangeValue(new BigDecimal(-0.001)),"Value cannot be less than zero");
+        assertEquals(item.validateChangeValue(BigDecimal.valueOf(-0.001)),"Value cannot be less than zero");
     }
 
     @Test
@@ -96,11 +96,11 @@ public class KeyItemTest {
         assertTrue(item.getAuditedValue().equals(new BigDecimal(2)));
 
         //when
-        item.changeAuditedValue(new BigDecimal(2.3335));
+        item.changeAuditedValue(BigDecimal.valueOf(2.3335));
 
         //then
-        assertEquals(item.getAuditedValue(),new BigDecimal(2.333).setScale(3, BigDecimal.ROUND_HALF_UP));
-        assertFalse(item.getAuditedValue().equals(new BigDecimal(2.334).setScale(3, BigDecimal.ROUND_HALF_UP)));
+        assertEquals(item.getAuditedValue(),BigDecimal.valueOf(2.333).setScale(3, BigDecimal.ROUND_HALF_UP));
+        assertFalse(item.getAuditedValue().equals(BigDecimal.valueOf(2.334).setScale(3, BigDecimal.ROUND_HALF_UP)));
 
     }
 
@@ -116,7 +116,7 @@ public class KeyItemTest {
         assertTrue(item.getAuditedValue().equals(new BigDecimal(2)));
 
         //when, then
-        assertEquals(item.validateChangeAuditedValue(new BigDecimal(-0.001)),"Value cannot be less than zero");
+        assertEquals(item.validateChangeAuditedValue(BigDecimal.valueOf(-0.001)),"Value cannot be less than zero");
     }
 
     @Test
@@ -131,11 +131,11 @@ public class KeyItemTest {
         assertTrue(item.getSourceValue().equals(new BigDecimal(2)));
 
         //when
-        item.changeSourceValue(new BigDecimal(2.335));
+        item.changeSourceValue(BigDecimal.valueOf(2.335));
 
         //then
-        assertEquals(item.getSourceValue(),new BigDecimal(2.33).setScale(2, BigDecimal.ROUND_HALF_UP));
-        assertFalse(item.getSourceValue().equals(new BigDecimal(2.34).setScale(2, BigDecimal.ROUND_HALF_UP)));
+        assertEquals(item.getSourceValue(),BigDecimal.valueOf(2.33).setScale(2, BigDecimal.ROUND_HALF_UP));
+        assertFalse(item.getSourceValue().equals(BigDecimal.valueOf(2.34).setScale(2, BigDecimal.ROUND_HALF_UP)));
 
     }
 
@@ -151,7 +151,7 @@ public class KeyItemTest {
         assertTrue(item.getSourceValue().equals(new BigDecimal(2)));
 
         //when, then
-        assertEquals(item.validateChangeSourceValue(new BigDecimal(-0.001)),"Source Value must be positive");
+        assertEquals(item.validateChangeSourceValue(BigDecimal.valueOf(-0.001)),"Source Value must be positive");
         assertEquals(item.validateChangeSourceValue(BigDecimal.ZERO),null);
     }
 

--- a/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/keytable/KeyValueMethodTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/keytable/KeyValueMethodTest.java
@@ -41,14 +41,14 @@ public class KeyValueMethodTest {
 
         for(int i = 0; i < 1; i = i+1) {
             KeyItem budgetKeyItem = new KeyItem();
-            budgetKeyItem.setValue(new BigDecimal(999.999));
+            budgetKeyItem.setValue(BigDecimal.valueOf(999.999));
             budgetKeyItems.add(budgetKeyItem);
         }
         keyTable.setItems(budgetKeyItems);
         keyTable.setPrecision(3);
 
         // then
-        assertThat(method.keySum(keyTable)).isEqualTo(new BigDecimal(999.999).setScale(3, BigDecimal.ROUND_HALF_UP));
+        assertThat(method.keySum(keyTable)).isEqualTo(BigDecimal.valueOf(999.999).setScale(3, BigDecimal.ROUND_HALF_UP));
         assertThat(method.isValid(keyTable)).isEqualTo(false);
 
 
@@ -66,7 +66,7 @@ public class KeyValueMethodTest {
 
         for(int i = 0; i < 1; i = i+1) {
                         KeyItem budgetKeyItem = new KeyItem();
-                        budgetKeyItem.setValue(new BigDecimal(999.9999));
+                        budgetKeyItem.setValue(BigDecimal.valueOf(999.9999));
                         budgetKeyItems.add(budgetKeyItem);
                     }
         keyTable.setItems(budgetKeyItems);
@@ -90,7 +90,7 @@ public class KeyValueMethodTest {
 
         for(int i = 0; i < 1; i = i+1) {
             KeyItem budgetKeyItem = new KeyItem();
-            budgetKeyItem.setValue(new BigDecimal(1000.0001));
+            budgetKeyItem.setValue(BigDecimal.valueOf(1000.0001));
             budgetKeyItems.add(budgetKeyItem);
         }
         keyTable.setItems(budgetKeyItems);

--- a/estatioapp/dom/src/test/java/org/estatio/dom/lease/LeaseTermForPercentageTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/lease/LeaseTermForPercentageTest.java
@@ -156,8 +156,8 @@ public class LeaseTermForPercentageTest {
 
         @Test
         public void testValidate(){
-            assertThat(term.validateChangeParameters(new BigDecimal(-0.00001)), is("Percentage should be between 0 and 100"));
-            assertThat(term.validateChangeParameters(new BigDecimal(100.00001)), is("Percentage should be between 0 and 100"));
+            assertThat(term.validateChangeParameters(BigDecimal.valueOf(-0.00001)), is("Percentage should be between 0 and 100"));
+            assertThat(term.validateChangeParameters(BigDecimal.valueOf(100.00001)), is("Percentage should be between 0 and 100"));
             assertNull(term.validateChangeParameters(new BigDecimal(0)));
             assertNull(term.validateChangeParameters(new BigDecimal(100)));
         }

--- a/estatioapp/dom/src/test/java/org/estatio/dom/lease/LeaseTermForTaxTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/lease/LeaseTermForTaxTest.java
@@ -75,8 +75,8 @@ public class LeaseTermForTaxTest {
         @Test
         public void normal() throws Exception {
             // given
-            term1.setTaxPercentage(new BigDecimal(1.00));
-            term1.setRecoverablePercentage(new BigDecimal(50.00));
+            term1.setTaxPercentage(BigDecimal.valueOf(1.00));
+            term1.setRecoverablePercentage(BigDecimal.valueOf(50.00));
             // when
             term1.doAlign();
             // then
@@ -88,8 +88,8 @@ public class LeaseTermForTaxTest {
         @Test
         public void overrides() throws Exception {
             // given
-            term1.setTaxPercentage(new BigDecimal(1.00));
-            term1.setRecoverablePercentage(new BigDecimal(50.00));
+            term1.setTaxPercentage(BigDecimal.valueOf(1.00));
+            term1.setRecoverablePercentage(BigDecimal.valueOf(50.00));
             term1.setPayableValue(new BigDecimal("222.00"));
             term1.setOverridePayableValue(true);
             term1.setTaxValue(new BigDecimal("111.00"));
@@ -106,8 +106,8 @@ public class LeaseTermForTaxTest {
         @Test
         public void noRent() throws Exception {
             // given
-            term2.setTaxPercentage(new BigDecimal(1.00));
-            term2.setRecoverablePercentage(new BigDecimal(50.00));
+            term2.setTaxPercentage(BigDecimal.valueOf(1.00));
+            term2.setRecoverablePercentage(BigDecimal.valueOf(50.00));
             term2.setPayableValue(new BigDecimal("222.00"));
             term2.setOverridePayableValue(true);
             term2.setTaxValue(new BigDecimal("111.00"));
@@ -131,7 +131,7 @@ public class LeaseTermForTaxTest {
             term = new LeaseTermForTax() {
                 @Override
                 public BigDecimal rentValueForDate() {
-                    return new BigDecimal(20000.00);
+                    return BigDecimal.valueOf(20000.00);
                 };
             };
         }
@@ -166,7 +166,7 @@ public class LeaseTermForTaxTest {
             term = new LeaseTermForTax() {
                 @Override
                 public BigDecimal rentValueForDate() {
-                    return new BigDecimal(20000.00);
+                    return BigDecimal.valueOf(20000.00);
                 };
             };
         }

--- a/estatioapp/fixture/src/main/java/org/estatio/fixture/budget/BudgetsForOxf.java
+++ b/estatioapp/fixture/src/main/java/org/estatio/fixture/budget/BudgetsForOxf.java
@@ -42,10 +42,10 @@ public class BudgetsForOxf extends BudgetAbstact {
 
         // exec
         Property property = propertyRepository.findPropertyByReference(PropertyForOxfGb.REF);
-        final BigDecimal VALUE1 = new BigDecimal(30000.55);
-        final BigDecimal VALUE2 = new BigDecimal(40000.35);
-        final BigDecimal VALUE3 = new BigDecimal(30500.99);
-        final BigDecimal VALUE4 = new BigDecimal(40600.01);
+        final BigDecimal VALUE1 = BigDecimal.valueOf(30000.55);
+        final BigDecimal VALUE2 = BigDecimal.valueOf(40000.35);
+        final BigDecimal VALUE3 = BigDecimal.valueOf(30500.99);
+        final BigDecimal VALUE4 = BigDecimal.valueOf(40600.01);
         final Charge charge1 = chargesRepository.findByReference(ChargeRefData.GB_SERVICE_CHARGE_ONBUDGET1);
         final Charge charge2 = chargesRepository.findByReference(ChargeRefData.GB_SERVICE_CHARGE_ONBUDGET2);
 

--- a/estatioapp/fixture/src/main/java/org/estatio/fixture/lease/LeaseItemAndLeaseTermForPercentageForOxfMiracl005Gb.java
+++ b/estatioapp/fixture/src/main/java/org/estatio/fixture/lease/LeaseItemAndLeaseTermForPercentageForOxfMiracl005Gb.java
@@ -47,7 +47,7 @@ public class LeaseItemAndLeaseTermForPercentageForOxfMiracl005Gb extends LeaseIt
                 LEASE_REF,
                 AT_PATH,
                 lease.getStartDate().withDayOfYear(1).plusYears(1), null,
-                new BigDecimal(1.50),
+                BigDecimal.valueOf(1.50),
                 executionContext);
     }
 }

--- a/estatioapp/fixture/src/main/java/org/estatio/fixture/lease/LeaseItemAndLeaseTermForPercentageForOxfTopModel001Gb.java
+++ b/estatioapp/fixture/src/main/java/org/estatio/fixture/lease/LeaseItemAndLeaseTermForPercentageForOxfTopModel001Gb.java
@@ -47,7 +47,7 @@ public class LeaseItemAndLeaseTermForPercentageForOxfTopModel001Gb extends Lease
                 LEASE_REF,
                 AT_PATH,
                 lease.getStartDate().withDayOfYear(1).plusYears(1), null,
-                new BigDecimal(1.50),
+                BigDecimal.valueOf(1.50),
                 executionContext);
     }
 }

--- a/estatioapp/integtests/src/test/java/org/estatio/integtests/lease/LeaseTermsForPercentageTest.java
+++ b/estatioapp/integtests/src/test/java/org/estatio/integtests/lease/LeaseTermsForPercentageTest.java
@@ -68,7 +68,7 @@ public class LeaseTermsForPercentageTest extends EstatioIntegrationTest {
             indexTerm2 = (LeaseTermForIndexable) indexTerm1.getNext();
 
             torTerm = (LeaseTermForTurnoverRent) topmodelLease.findFirstItemOfType(LeaseItemType.TURNOVER_RENT).getTerms().first();
-            torTerm.setAuditedTurnover(new BigDecimal(1111111.00));
+            torTerm.setAuditedTurnover(BigDecimal.valueOf(1111111.00));
             topmodelLease.verifyUntil(new LocalDate(2012, 01, 01));
 
             // when


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2111 - “ "BigDecimal(double)" should not be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2111
Please let me know if you have any questions.
Ayman Abdelghany.