### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/estatioapp/dom/src/main/java/org/estatio/dom/agreement/Agreement.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/agreement/Agreement.java
@@ -256,7 +256,7 @@ public abstract class Agreement
 
     // //////////////////////////////////////
 
-    private WithIntervalMutable.Helper<Agreement> changeDates = new WithIntervalMutable.Helper<Agreement>(this);
+    private WithIntervalMutable.Helper<Agreement> changeDates = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<Agreement> getChangeDates() {
         return changeDates;
@@ -325,7 +325,7 @@ public abstract class Agreement
     @Collection(editing = Editing.DISABLED)
     @CollectionLayout(render = RenderType.EAGERLY)
     @Getter @Setter
-    private SortedSet<AgreementRole> roles = new TreeSet<AgreementRole>();
+    private SortedSet<AgreementRole> roles = new TreeSet<>();
 
     @MemberOrder(name = "roles", sequence = "1")
     public Agreement newRole(

--- a/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRole.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRole.java
@@ -124,7 +124,7 @@ public class AgreementRole
         implements WithIntervalContiguous<AgreementRole>, WithApplicationTenancyProperty {
 
     private final WithIntervalContiguous.Helper<AgreementRole> helper =
-            new WithIntervalContiguous.Helper<AgreementRole>(this);
+            new WithIntervalContiguous.Helper<>(this);
 
     // //////////////////////////////////////
 
@@ -356,7 +356,7 @@ public class AgreementRole
     @CollectionLayout(render = RenderType.EAGERLY)
     @Collection(editing = Editing.DISABLED)
     @Getter @Setter
-    private SortedSet<AgreementRoleCommunicationChannel> communicationChannels = new TreeSet<AgreementRoleCommunicationChannel>();
+    private SortedSet<AgreementRoleCommunicationChannel> communicationChannels = new TreeSet<>();
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRoleCommunicationChannel.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRoleCommunicationChannel.java
@@ -97,7 +97,7 @@ public class AgreementRoleCommunicationChannel
         implements WithIntervalContiguous<AgreementRoleCommunicationChannel>, WithApplicationTenancyProperty {
 
     private WithIntervalContiguous.Helper<AgreementRoleCommunicationChannel> helper =
-            new WithIntervalContiguous.Helper<AgreementRoleCommunicationChannel>(this);
+            new WithIntervalContiguous.Helper<>(this);
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAsset.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAsset.java
@@ -161,7 +161,7 @@ public abstract class FixedAsset<X extends FixedAsset<X>>
     @CollectionLayout(render = RenderType.EAGERLY)
     @javax.jdo.annotations.Persistent(mappedBy = "asset")
     @Getter @Setter
-    private SortedSet<FixedAssetRole> roles = new TreeSet<FixedAssetRole>();
+    private SortedSet<FixedAssetRole> roles = new TreeSet<>();
 
     public FixedAsset newRole(
             final @ParameterLayout(named = "Type") FixedAssetRoleType type,

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAssetRole.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAssetRole.java
@@ -94,7 +94,7 @@ public class FixedAssetRole
         implements WithIntervalContiguous<FixedAssetRole>, WithApplicationTenancyProperty {
 
     private WithIntervalContiguous.Helper<FixedAssetRole> helper =
-            new WithIntervalContiguous.Helper<FixedAssetRole>(this);
+            new WithIntervalContiguous.Helper<>(this);
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/Property.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/Property.java
@@ -173,7 +173,7 @@ public class Property
     @CollectionLayout(render = RenderType.EAGERLY)
     @Deprecated
     @Getter @Setter
-    private SortedSet<Unit> units = new TreeSet<Unit>();
+    private SortedSet<Unit> units = new TreeSet<>();
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/Unit.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/Unit.java
@@ -186,7 +186,7 @@ public class Unit
 
     // //////////////////////////////////////
 
-    private WithIntervalMutable.Helper<Unit> changeDates = new WithIntervalMutable.Helper<Unit>(this);
+    private WithIntervalMutable.Helper<Unit> changeDates = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<Unit> getChangeDates() {
         return changeDates;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/registration/FixedAssetRegistration.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/registration/FixedAssetRegistration.java
@@ -122,7 +122,7 @@ public abstract class FixedAssetRegistration
 
     // //////////////////////////////////////
 
-    private WithIntervalMutable.Helper<FixedAssetRegistration> changeDates = new WithIntervalMutable.Helper<FixedAssetRegistration>(this);
+    private WithIntervalMutable.Helper<FixedAssetRegistration> changeDates = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<FixedAssetRegistration> getChangeDates() {
         return changeDates;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/DistributionService.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/DistributionService.java
@@ -175,7 +175,7 @@ public class DistributionService {
 
         }
 
-        ArrayList<Distributable> output = new ArrayList<Distributable>();
+        ArrayList<Distributable> output = new ArrayList<>();
 
         for (OutputHelper helper : outputHelperList) {
             output.add(helper.distributable);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/budget/Budget.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/budget/Budget.java
@@ -146,7 +146,7 @@ public class Budget extends EstatioDomainObject<Budget> implements WithIntervalM
         return LocalDateInterval.including(this.getStartDate(), this.getEndDate()).contains(date);
     }
 
-    private WithIntervalMutable.Helper<Budget> changeDates = new WithIntervalMutable.Helper<Budget>(this);
+    private WithIntervalMutable.Helper<Budget> changeDates = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<Budget> getChangeDates() {
         return changeDates;
@@ -181,7 +181,7 @@ public class Budget extends EstatioDomainObject<Budget> implements WithIntervalM
     @CollectionLayout(render= RenderType.EAGERLY)
     @Persistent(mappedBy = "budget", dependentElement = "true")
     @Getter @Setter
-    private SortedSet<BudgetItem> items = new TreeSet<BudgetItem>();
+    private SortedSet<BudgetItem> items = new TreeSet<>();
 
 
     @PropertyLayout(hidden = Where.EVERYWHERE)

--- a/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/budgetcalculation/BudgetCalculation.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/budgetcalculation/BudgetCalculation.java
@@ -102,7 +102,7 @@ public class BudgetCalculation extends EstatioDomainObject<BudgetCalculation> im
     @Getter @Setter
     @CollectionLayout(hidden = Where.EVERYWHERE)
     @Persistent(mappedBy = "budgetCalculation", dependentElement = "true")
-    private SortedSet<BudgetCalculationLink> budgetCalculationLinks = new TreeSet<BudgetCalculationLink>();
+    private SortedSet<BudgetCalculationLink> budgetCalculationLinks = new TreeSet<>();
 
     @Action(semantics = SemanticsOf.SAFE)
     @ActionLayout(contributed = Contributed.AS_ASSOCIATION)

--- a/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/keytable/KeyTable.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/keytable/KeyTable.java
@@ -179,7 +179,7 @@ public class KeyTable extends EstatioDomainObject<Budget> implements WithApplica
     @CollectionLayout(render = RenderType.EAGERLY)
     @Persistent(mappedBy = "keyTable", dependentElement = "true")
     @Getter @Setter
-    private SortedSet<KeyItem> items = new TreeSet<KeyItem>();
+    private SortedSet<KeyItem> items = new TreeSet<>();
 
     public KeyTable generateItems(
             @Parameter(optionality = Optionality.OPTIONAL)

--- a/estatioapp/dom/src/main/java/org/estatio/dom/charge/ChargeGroup.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/charge/ChargeGroup.java
@@ -104,6 +104,6 @@ public class ChargeGroup
     @CollectionLayout(render = RenderType.EAGERLY)
     @javax.jdo.annotations.Persistent(mappedBy = "group")
     @Getter @Setter
-    private SortedSet<Charge> charges = new TreeSet<Charge>();
+    private SortedSet<Charge> charges = new TreeSet<>();
 
 }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/document/Document.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/document/Document.java
@@ -128,7 +128,7 @@ public class Document implements Comparable<Document>, WithIntervalMutable<Docum
 
     // //////////////////////////////////////
 
-    private WithIntervalMutable.Helper<Document> intervalHelper = new WithIntervalMutable.Helper<Document>(this);
+    private WithIntervalMutable.Helper<Document> intervalHelper = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<Document> getHelper() {
         return intervalHelper;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/index/Index.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/index/Index.java
@@ -146,7 +146,7 @@ public class Index
     @Persistent(mappedBy = "index")
     @CollectionLayout(render = RenderType.EAGERLY)
     @Getter @Setter
-    private SortedSet<IndexBase> indexBases = new TreeSet<IndexBase>();
+    private SortedSet<IndexBase> indexBases = new TreeSet<>();
 
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @MemberOrder(sequence = "1")

--- a/estatioapp/dom/src/main/java/org/estatio/dom/index/IndexBase.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/index/IndexBase.java
@@ -149,7 +149,7 @@ public class IndexBase
     @Persistent(mappedBy = "indexBase")
     @CollectionLayout(render = RenderType.EAGERLY)
     @Getter @Setter
-    private SortedSet<IndexValue> values = new TreeSet<IndexValue>();
+    private SortedSet<IndexValue> values = new TreeSet<>();
 
     @Programmatic
     public BigDecimal factorForDate(final LocalDate date) {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/invoice/Invoice.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/invoice/Invoice.java
@@ -348,7 +348,7 @@ public class Invoice
     @CollectionLayout(render = RenderType.EAGERLY)
     @javax.jdo.annotations.Persistent(mappedBy = "invoice")
     @Getter @Setter
-    private SortedSet<InvoiceItem> items = new TreeSet<InvoiceItem>();
+    private SortedSet<InvoiceItem> items = new TreeSet<>();
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/InvoicingFrequency.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/InvoicingFrequency.java
@@ -145,7 +145,7 @@ public enum InvoicingFrequency {
     }
 
     public List<InvoicingInterval> intervalsInRange(final LocalDate periodStartDate, final LocalDate nextPeriodStartDate) {
-        List<InvoicingInterval> invoicingIntervals = new ArrayList<InvoicingInterval>();
+        List<InvoicingInterval> invoicingIntervals = new ArrayList<>();
         for (Interval interval : CalendarUtils.intervalsInRange(periodStartDate, nextPeriodStartDate, this.rrule)) {
             invoicingIntervals.add(new InvoicingInterval(interval, dueDateOfInterval(interval)));
         }
@@ -155,7 +155,7 @@ public enum InvoicingFrequency {
     public List<InvoicingInterval> intervalsInDueDateRange(
             final LocalDate periodStartDate,
             final LocalDate periodEndDate) {
-        List<InvoicingInterval> invoicingIntervals = new ArrayList<InvoicingInterval>();
+        List<InvoicingInterval> invoicingIntervals = new ArrayList<>();
         if (periodEndDate.compareTo(periodStartDate) > 0) {
             for (Interval interval : CalendarUtils.intervalsInRange(periodStartDate, periodEndDate, this.rrule)) {
                 LocalDate dueDate = dueDateOfInterval(interval);
@@ -170,7 +170,7 @@ public enum InvoicingFrequency {
     public List<InvoicingInterval> intervalsInDueDateRange(
             final LocalDateInterval rangeInterval,
             final LocalDateInterval sourceInterval) {
-        List<InvoicingInterval> invoicingIntervals = new ArrayList<InvoicingInterval>();
+        List<InvoicingInterval> invoicingIntervals = new ArrayList<>();
         if (rrule == null) {
             LocalDate dueDateOfSourceInterval = dueDateOfInterval(sourceInterval);
             if (rangeInterval.contains(dueDateOfSourceInterval)) {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/Lease.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/Lease.java
@@ -370,7 +370,7 @@ public class Lease
     @CollectionLayout(render = RenderType.EAGERLY)
     @javax.jdo.annotations.Persistent(mappedBy = "lease")
     @Getter @Setter
-    private SortedSet<Occupancy> occupancies = new TreeSet<Occupancy>();
+    private SortedSet<Occupancy> occupancies = new TreeSet<>();
 
     /**
      * The action to relate a lease to a unit. A lease can occupy unlimited
@@ -410,7 +410,7 @@ public class Lease
     @javax.jdo.annotations.Persistent(mappedBy = "lease", defaultFetchGroup = "true")
     @CollectionLayout(render = RenderType.EAGERLY)
     @Getter @Setter
-    private SortedSet<LeaseItem> items = new TreeSet<LeaseItem>();
+    private SortedSet<LeaseItem> items = new TreeSet<>();
 
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     public LeaseItem newItem(
@@ -506,7 +506,7 @@ public class Lease
 
     @Programmatic
     public List<LeaseItem> findItemsOfType(final LeaseItemType type) {
-        List<LeaseItem> items = new ArrayList<LeaseItem>();
+        List<LeaseItem> items = new ArrayList<>();
         for (LeaseItem item : getItems()) {
             if (item.getType().equals(type)) {
                 items.add(item);
@@ -531,7 +531,7 @@ public class Lease
     @CollectionLayout(render = RenderType.EAGERLY)
     @javax.jdo.annotations.Persistent(mappedBy = "lease")
     @Getter @Setter
-    private SortedSet<BreakOption> breakOptions = new TreeSet<BreakOption>();
+    private SortedSet<BreakOption> breakOptions = new TreeSet<>();
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseItem.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseItem.java
@@ -302,7 +302,7 @@ public class LeaseItem
 
     // //////////////////////////////////////
 
-    private WithIntervalMutable.Helper<LeaseItem> changeDates = new WithIntervalMutable.Helper<LeaseItem>(this);
+    private WithIntervalMutable.Helper<LeaseItem> changeDates = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<LeaseItem> getChangeDates() {
         return changeDates;
@@ -537,7 +537,7 @@ public class LeaseItem
     @javax.jdo.annotations.Persistent(mappedBy = "leaseItem")
     @CollectionLayout(render = RenderType.EAGERLY, paged = PAGE_SIZE)
     @Getter @Setter
-    private SortedSet<LeaseTerm> terms = new TreeSet<LeaseTerm>();
+    private SortedSet<LeaseTerm> terms = new TreeSet<>();
 
     @Programmatic
     public LeaseTerm findTerm(final LocalDate startDate) {
@@ -632,7 +632,7 @@ public class LeaseItem
             final LocalDateInterval interval,
             final LocalDate dueDate
             ) {
-        List<CalculationResult> results = new ArrayList<CalculationResult>();
+        List<CalculationResult> results = new ArrayList<>();
         for (LeaseTerm term : getTerms()) {
             results.addAll(term.calculationResults(interval, dueDate));
         }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTerm.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTerm.java
@@ -206,7 +206,7 @@ public abstract class LeaseTerm
 
     // //////////////////////////////////////
 
-    private WithIntervalMutable.Helper<LeaseTerm> changeDates = new WithIntervalMutable.Helper<LeaseTerm>(this);
+    private WithIntervalMutable.Helper<LeaseTerm> changeDates = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<LeaseTerm> getChangeDates() {
         return changeDates;
@@ -331,7 +331,7 @@ public abstract class LeaseTerm
     @Persistent(mappedBy = "leaseTerm")
     @CollectionLayout(render = RenderType.EAGERLY)
     @Getter @Setter
-    private SortedSet<InvoiceItemForLease> invoiceItems = new TreeSet<InvoiceItemForLease>();
+    private SortedSet<InvoiceItemForLease> invoiceItems = new TreeSet<>();
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForPercentage.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForPercentage.java
@@ -99,7 +99,7 @@ public class LeaseTermForPercentage extends LeaseTerm {
             // Collect all results
             BigDecimal newOriginalValue = BigDecimal.ZERO;
             List<LeaseItem> rentItems = getLeaseItem().getLease().findItemsOfType(LeaseItemType.RENT);
-            List<InvoiceCalculationService.CalculationResult> calculationResults = new ArrayList<InvoiceCalculationService.CalculationResult>();
+            List<InvoiceCalculationService.CalculationResult> calculationResults = new ArrayList<>();
             for (LeaseItem rentItem : rentItems) {
                 calculationResults.addAll(
                         rentItem.calculationResults(getInterval(), this.getEndDate().plusYears(1)));

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTurnoverRent.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTurnoverRent.java
@@ -151,7 +151,7 @@ public class LeaseTermForTurnoverRent extends LeaseTerm {
             // Collect all results
             BigDecimal newContractualRent = BigDecimal.ZERO;
             List<LeaseItem> rentItems = getLeaseItem().getLease().findItemsOfType(LeaseItemType.RENT);
-            List<CalculationResult> calculationResults = new ArrayList<CalculationResult>();
+            List<CalculationResult> calculationResults = new ArrayList<>();
             for (LeaseItem rentItem : rentItems) {
                 calculationResults.addAll(
                         rentItem.calculationResults(getInterval(), this.getEndDate().plusYears(1)));

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTerms.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTerms.java
@@ -168,7 +168,7 @@ public class LeaseTerms extends UdoDomainRepositoryAndFactory<LeaseTerm> {
     @MemberOrder(name = "Leases", sequence = "30")
     public List<LeaseTerm> findTermsWithInvalidInterval() {
         List<LeaseTerm> lts = allLeaseTerms();
-        List<LeaseTerm> returnList = new ArrayList<LeaseTerm>();
+        List<LeaseTerm> returnList = new ArrayList<>();
         LocalDateInterval ldi;
         for (LeaseTerm lt : lts) {
             try {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/Occupancy.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/Occupancy.java
@@ -158,7 +158,7 @@ public class Occupancy
 
     // //////////////////////////////////////
 
-    private WithIntervalMutable.Helper<Occupancy> changeDates = new WithIntervalMutable.Helper<Occupancy>(this);
+    private WithIntervalMutable.Helper<Occupancy> changeDates = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<Occupancy> getChangeDates() {
         return changeDates;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/invoicing/InvoiceCalculationService.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/invoicing/InvoiceCalculationService.java
@@ -149,14 +149,14 @@ public class InvoiceCalculationService extends UdoDomainService<InvoiceCalculati
                     SortedSet<LeaseItem> leaseItems =
                             parameters.leaseItem() == null ?
                                     lease.getItems() :
-                                    new TreeSet<LeaseItem>(Arrays.asList(parameters.leaseItem()));
+                                    new TreeSet<>(Arrays.asList(parameters.leaseItem()));
                     for (LeaseItem leaseItem : leaseItems) {
                         if (!leaseItem.getStatus().equals(LeaseItemStatus.SUSPENDED)) {
                             if (parameters.leaseItemTypes() == null || parameters.leaseItemTypes().contains(leaseItem.getType())) {
                                 SortedSet<LeaseTerm> leaseTerms =
                                         parameters.leaseTerm() == null ?
                                                 leaseItem.getTerms() :
-                                                new TreeSet<LeaseTerm>(Arrays.asList(parameters.leaseTerm()));
+                                                new TreeSet<>(Arrays.asList(parameters.leaseTerm()));
                                 for (LeaseTerm leaseTerm : leaseTerms) {
                                     final List<CalculationResult> results;
                                     results = calculateDueDateRange(leaseTerm, parameters);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/tags/Sector.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/tags/Sector.java
@@ -89,7 +89,7 @@ public class Sector
     // //////////////////////////////////////
 
     @javax.jdo.annotations.Persistent(mappedBy = "sector")
-    private SortedSet<Activity> activities = new TreeSet<Activity>();
+    private SortedSet<Activity> activities = new TreeSet<>();
 
     public SortedSet<Activity> getActivities() {
         return activities;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/Party.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/Party.java
@@ -118,14 +118,14 @@ public abstract class Party
     @Property(hidden = Where.EVERYWHERE)
     @javax.jdo.annotations.Persistent(mappedBy = "party")
     @Getter @Setter
-    private SortedSet<AgreementRole> agreements = new TreeSet<AgreementRole>();
+    private SortedSet<AgreementRole> agreements = new TreeSet<>();
 
     // //////////////////////////////////////
 
     @Property(hidden = Where.EVERYWHERE)
     @javax.jdo.annotations.Persistent(mappedBy = "party")
     @Getter @Setter
-    private SortedSet<PartyRegistration> registrations = new TreeSet<PartyRegistration>();
+    private SortedSet<PartyRegistration> registrations = new TreeSet<>();
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/PartyRegistration.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/PartyRegistration.java
@@ -118,7 +118,7 @@ public class PartyRegistration
     // //////////////////////////////////////
 
     private WithIntervalMutable.Helper<PartyRegistration> changeDates =
-            new WithIntervalMutable.Helper<PartyRegistration>(this);
+            new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<PartyRegistration> getChangeDates() {
         return changeDates;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/relationship/PartyRelationshipViewService.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/relationship/PartyRelationshipViewService.java
@@ -54,7 +54,7 @@ public class PartyRelationshipViewService extends UdoDomainService<PartyRelation
     @ActionSemantics(Of.SAFE)
     @NotContributed(As.ACTION)
     public List<PartyRelationshipView> relationships(Party party) {
-        List<PartyRelationshipView> partyRelationshipViews = new ArrayList<PartyRelationshipView>();
+        List<PartyRelationshipView> partyRelationshipViews = new ArrayList<>();
         final List<PartyRelationship> relationships = partyRelationships.findByParty(party);
         for (PartyRelationship partyRelationship : relationships) {
             PartyRelationshipView viewModel = new PartyRelationshipView(partyRelationship, party);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/Program.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/Program.java
@@ -130,7 +130,7 @@ public class Program
     //TODO: decouple sorted set [momentarily needed by code in  ProgramRole getPredecessor() etc.
 
     @javax.jdo.annotations.Persistent(mappedBy = "program")
-    private SortedSet<ProgramRole> roles = new TreeSet<ProgramRole>();
+    private SortedSet<ProgramRole> roles = new TreeSet<>();
 
     @CollectionLayout(render=RenderType.EAGERLY, hidden=Where.EVERYWHERE)
     public SortedSet<ProgramRole> getRoles() {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/ProgramRole.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/ProgramRole.java
@@ -118,7 +118,7 @@ public class ProgramRole
         implements WithIntervalContiguous<ProgramRole>, WithApplicationTenancyGlobalAndCountry {
 
     private WithIntervalContiguous.Helper<ProgramRole> helper =
-            new WithIntervalContiguous.Helper<ProgramRole>(this);
+            new WithIntervalContiguous.Helper<>(this);
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/Project.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/Project.java
@@ -164,7 +164,7 @@ public class Project extends UdoDomainObject<Project> implements
     //TODO: decouple sorted set [momentarily needed by code in  ProjectRole getPredecessor() etc.
 
 	@javax.jdo.annotations.Persistent(mappedBy = "project")
-	private SortedSet<ProjectRole> roles = new TreeSet<ProjectRole>();
+	private SortedSet<ProjectRole> roles = new TreeSet<>();
 
 	@CollectionLayout(render = RenderType.EAGERLY, hidden = Where.EVERYWHERE)
 	public SortedSet<ProjectRole> getRoles() {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/ProjectRole.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/ProjectRole.java
@@ -118,7 +118,7 @@ public class ProjectRole
 {
 
     private WithIntervalContiguous.Helper<ProjectRole> helper =
-            new WithIntervalContiguous.Helper<ProjectRole>(this);
+            new WithIntervalContiguous.Helper<>(this);
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/tax/Tax.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/tax/Tax.java
@@ -142,7 +142,7 @@ public class Tax
     @javax.jdo.annotations.Persistent(mappedBy = "tax")
     @CollectionLayout(render = RenderType.EAGERLY)
     @Getter @Setter
-    private SortedSet<TaxRate> rates = new TreeSet<TaxRate>();
+    private SortedSet<TaxRate> rates = new TreeSet<>();
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/tax/TaxRate.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/tax/TaxRate.java
@@ -107,7 +107,7 @@ public class TaxRate
 
     // //////////////////////////////////////
 
-    private WithIntervalMutable.Helper<TaxRate> changeDates = new WithIntervalMutable.Helper<TaxRate>(this);
+    private WithIntervalMutable.Helper<TaxRate> changeDates = new WithIntervalMutable.Helper<>(this);
 
     WithIntervalMutable.Helper<TaxRate> getChangeDates() {
         return changeDates;

--- a/estatioapp/dom/src/main/java/org/estatio/domlink/LinkRepository.java
+++ b/estatioapp/dom/src/main/java/org/estatio/domlink/LinkRepository.java
@@ -109,7 +109,7 @@ public class LinkRepository extends UdoDomainRepositoryAndFactory<Link> {
     }
 
     public List<Link> findByClassName(final String className) {
-        return allMatches(new QueryDefault<Link>(Link.class,
+        return allMatches(new QueryDefault<>(Link.class,
                 "findByClassName",
                 "className", className));
     }

--- a/estatioapp/dom/src/main/java/org/estatio/domsettings/ApplicationSettingsServiceForEstatio.java
+++ b/estatioapp/dom/src/main/java/org/estatio/domsettings/ApplicationSettingsServiceForEstatio.java
@@ -56,8 +56,8 @@ public class ApplicationSettingsServiceForEstatio extends UdoDomainRepositoryAnd
     @Override
     public ApplicationSetting find(final String key) {
         return firstMatch(
-                new QueryDefault<ApplicationSettingForEstatio>(ApplicationSettingForEstatio.class, 
-                        "findByKey", 
+                new QueryDefault<>(ApplicationSettingForEstatio.class,
+                        "findByKey",
                         "key", key));
     }
 
@@ -68,7 +68,7 @@ public class ApplicationSettingsServiceForEstatio extends UdoDomainRepositoryAnd
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public List<ApplicationSetting> listAll() {
         return (List)allMatches(
-                new QueryDefault<ApplicationSettingForEstatio>(ApplicationSettingForEstatio.class, 
+                new QueryDefault<>(ApplicationSettingForEstatio.class,
                         "findAll"));
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/domsettings/UserSettingsServiceForEstatio.java
+++ b/estatioapp/dom/src/main/java/org/estatio/domsettings/UserSettingsServiceForEstatio.java
@@ -40,9 +40,9 @@ public class UserSettingsServiceForEstatio extends AbstractService implements Us
             final String user, 
             final String key) {
         return firstMatch(
-                new QueryDefault<UserSettingForEstatio>(UserSettingForEstatio.class, 
-                        "findByUserAndKey", 
-                        "user",user,
+                new QueryDefault<>(UserSettingForEstatio.class,
+                        "findByUserAndKey",
+                        "user", user,
                         "key", key));
     }
 
@@ -54,8 +54,8 @@ public class UserSettingsServiceForEstatio extends AbstractService implements Us
     @Override
     public List<UserSetting> listAllFor(final String user) {
         return (List)allMatches(
-                new QueryDefault<UserSettingForEstatio>(UserSettingForEstatio.class, 
-                        "findByUser", 
+                new QueryDefault<>(UserSettingForEstatio.class,
+                        "findByUser",
                         "user", user));
     }
 
@@ -66,7 +66,7 @@ public class UserSettingsServiceForEstatio extends AbstractService implements Us
     @Override
     public List<UserSetting> listAll() {
         return (List)allMatches(
-                new QueryDefault<UserSettingForEstatio>(UserSettingForEstatio.class, 
+                new QueryDefault<>(UserSettingForEstatio.class,
                         "findAll"));
     }
 

--- a/estatioapp/dom/src/test/java/org/estatio/dom/WithApplicationTenancyDefinedLevelsContractTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/WithApplicationTenancyDefinedLevelsContractTest.java
@@ -87,7 +87,7 @@ public class WithApplicationTenancyDefinedLevelsContractTest {
     }
 
     private <T extends WithApplicationTenancy> String test(Class<T> cls) {
-        return new WithApplicationTenancyDefinedLevelsContractTester<T>(cls).test();
+        return new WithApplicationTenancyDefinedLevelsContractTester<>(cls).test();
     }
 
 }

--- a/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/keytable/KeyValueMethodTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/budgeting/keytable/KeyValueMethodTest.java
@@ -35,7 +35,7 @@ public class KeyValueMethodTest {
         //given
         KeyValueMethod method = KeyValueMethod.PROMILLE;
         KeyTable keyTable = new KeyTable();
-        SortedSet<KeyItem> budgetKeyItems = new TreeSet<KeyItem>();
+        SortedSet<KeyItem> budgetKeyItems = new TreeSet<>();
 
         //when
 
@@ -60,7 +60,7 @@ public class KeyValueMethodTest {
         //given
         KeyValueMethod method = KeyValueMethod.PROMILLE;
         KeyTable keyTable = new KeyTable();
-        SortedSet<KeyItem> budgetKeyItems = new TreeSet<KeyItem>();
+        SortedSet<KeyItem> budgetKeyItems = new TreeSet<>();
 
         //when
 
@@ -84,7 +84,7 @@ public class KeyValueMethodTest {
         //given
         KeyValueMethod method = KeyValueMethod.PROMILLE;
         KeyTable keyTable = new KeyTable();
-        SortedSet<KeyItem> budgetKeyItems = new TreeSet<KeyItem>();
+        SortedSet<KeyItem> budgetKeyItems = new TreeSet<>();
 
         //when
 

--- a/udo/base/dom/src/main/java/org/estatio/dom/UdoDomainRepositoryAndFactory.java
+++ b/udo/base/dom/src/main/java/org/estatio/dom/UdoDomainRepositoryAndFactory.java
@@ -48,7 +48,7 @@ public abstract class UdoDomainRepositoryAndFactory<T> extends UdoDomainService<
     }
     
     protected QueryDefault<T> newQueryDefault(final String queryName, final Object... paramArgs) {
-        return new QueryDefault<T>(getEntityType(), queryName, paramArgs);
+        return new QueryDefault<>(getEntityType(), queryName, paramArgs);
     }
     
     // //////////////////////////////////////

--- a/udo/base/dom/src/main/java/org/estatio/dom/utils/CalendarUtils.java
+++ b/udo/base/dom/src/main/java/org/estatio/dom/utils/CalendarUtils.java
@@ -137,7 +137,7 @@ public final class CalendarUtils {
             final LocalDate startDate,
             final LocalDate endDate,
             final String rrule) {
-        List<LocalDateInterval> localDateIntervals = new ArrayList<LocalDateInterval>();
+        List<LocalDateInterval> localDateIntervals = new ArrayList<>();
         for (Interval interval : intervalsInRange(startDate, endDate, rrule)) {
             localDateIntervals.add(new LocalDateInterval(interval));
         }

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByCodeContractTestAbstract_compareTo.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByCodeContractTestAbstract_compareTo.java
@@ -69,7 +69,7 @@ public abstract class ComparableByCodeContractTestAbstract_compareTo {
     }
 
     private <T extends WithCodeComparable<T>> void test(Class<T> cls) {
-        new ComparableByCodeContractTester<T>(cls).test();
+        new ComparableByCodeContractTester<>(cls).test();
     }
 
 }

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByCodeContractTester.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByCodeContractTester.java
@@ -39,7 +39,7 @@ public class ComparableByCodeContractTester<T extends WithCodeComparable<T>> {
 
     public void test() {
         System.out.println("ComparableByCodeContractTester: " + cls.getName());
-        new ComparableContractTester<T>(orderedTuples()).test();
+        new ComparableContractTester<>(orderedTuples()).test();
 
         testToString();
         

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByDescriptionContractTestAbstract_compareTo.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByDescriptionContractTestAbstract_compareTo.java
@@ -69,7 +69,7 @@ public abstract class ComparableByDescriptionContractTestAbstract_compareTo {
     }
 
     private <T extends WithDescriptionComparable<T>> void test(Class<T> cls) {
-        new ComparableByDescriptionContractTester<T>(cls).test();
+        new ComparableByDescriptionContractTester<>(cls).test();
     }
 
 }

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByDescriptionContractTester.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByDescriptionContractTester.java
@@ -39,7 +39,7 @@ public class ComparableByDescriptionContractTester<T extends WithDescriptionComp
 
     public void test() {
         System.out.println("ComparableByDescriptionContractTester: " + cls.getName());
-        new ComparableContractTester<T>(orderedTuples()).test();
+        new ComparableContractTester<>(orderedTuples()).test();
 
         testToString();
     }

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByNameContractTestAbstract_compareTo.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByNameContractTestAbstract_compareTo.java
@@ -69,7 +69,7 @@ public abstract class ComparableByNameContractTestAbstract_compareTo {
     }
 
     private <T extends WithNameComparable<T>> void test(Class<T> cls) {
-        new ComparableByNameContractTester<T>(cls).test();
+        new ComparableByNameContractTester<>(cls).test();
     }
 
 }

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByNameContractTester.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByNameContractTester.java
@@ -39,7 +39,7 @@ public class ComparableByNameContractTester<T extends WithNameComparable<T>> {
 
     public void test() {
         System.out.println("ComparableByNameContractTester: " + cls.getName());
-        new ComparableContractTester<T>(orderedTuples()).test();
+        new ComparableContractTester<>(orderedTuples()).test();
         
         testToString();
         

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByReferenceContractTestAbstract_compareTo.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByReferenceContractTestAbstract_compareTo.java
@@ -68,7 +68,7 @@ public abstract class ComparableByReferenceContractTestAbstract_compareTo {
     }
 
     private <T extends WithReferenceComparable<T>> void test(Class<T> cls) {
-        new ComparableByReferenceContractTester<T>(cls).test();
+        new ComparableByReferenceContractTester<>(cls).test();
     }
 
 }

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByReferenceContractTester.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByReferenceContractTester.java
@@ -39,7 +39,7 @@ public class ComparableByReferenceContractTester<T extends WithReferenceComparab
 
     public void test() {
         System.out.println("ComparableByReferenceContractTester: " + cls.getName());
-        new ComparableContractTester<T>(orderedTuples()).test();
+        new ComparableContractTester<>(orderedTuples()).test();
 
         testToString();
         

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByTitleContractTestAbstract_compareTo.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByTitleContractTestAbstract_compareTo.java
@@ -69,7 +69,7 @@ public abstract class ComparableByTitleContractTestAbstract_compareTo {
     }
 
     private <T extends WithTitleComparable<T>> void test(Class<T> cls) {
-        new ComparableByTitleContractTester<T>(cls).test();
+        new ComparableByTitleContractTester<>(cls).test();
     }
 
 }

--- a/udo/base/dom/src/test/java/org/estatio/dom/ComparableByTitleContractTester.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/ComparableByTitleContractTester.java
@@ -39,7 +39,7 @@ public class ComparableByTitleContractTester<T extends WithTitleComparable<T>> {
 
     public void test() {
         System.out.println("ComparableByTitleContractTester: " + cls.getName());
-        new ComparableContractTester<T>(orderedTuples()).test();
+        new ComparableContractTester<>(orderedTuples()).test();
 
         testToString();
         

--- a/udo/base/dom/src/test/java/org/estatio/dom/FixtureDatumFactoriesForAnyPojo.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/FixtureDatumFactoriesForAnyPojo.java
@@ -27,7 +27,7 @@ public class FixtureDatumFactoriesForAnyPojo {
         try {
             final T obj1 = runtimeType.newInstance();
             final T obj2 = runtimeType.newInstance();
-            return new FixtureDatumFactory<T>(compileTimeType, obj1, obj2);
+            return new FixtureDatumFactory<>(compileTimeType, obj1, obj2);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/udo/base/dom/src/test/java/org/estatio/dom/FixtureDatumFactoriesForApplib.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/FixtureDatumFactoriesForApplib.java
@@ -25,7 +25,7 @@ import org.estatio.dom.PojoTester.FixtureDatumFactory;
 public class FixtureDatumFactoriesForApplib {
 
 	public static FixtureDatumFactory<Date> dates() {
-		return new FixtureDatumFactory<Date>(Date.class, new Date(2012, 7, 19), new Date(2012, 7, 20), new Date(2012, 8, 19), new Date(2013, 7, 19));
+		return new FixtureDatumFactory<>(Date.class, new Date(2012, 7, 19), new Date(2012, 7, 20), new Date(2012, 8, 19), new Date(2013, 7, 19));
 	}
 
 

--- a/udo/base/dom/src/test/java/org/estatio/dom/FixtureDatumFactoriesForJoda.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/FixtureDatumFactoriesForJoda.java
@@ -25,7 +25,7 @@ import org.estatio.dom.PojoTester.FixtureDatumFactory;
 public class FixtureDatumFactoriesForJoda {
 
 	public static FixtureDatumFactory<LocalDate> dates() {
-		return new FixtureDatumFactory<LocalDate>(LocalDate.class, new LocalDate(2012, 7, 19), new LocalDate(2012, 7, 20), new LocalDate(2012, 8, 19), new LocalDate(2013, 7, 19));
+		return new FixtureDatumFactory<>(LocalDate.class, new LocalDate(2012, 7, 19), new LocalDate(2012, 7, 20), new LocalDate(2012, 8, 19), new LocalDate(2013, 7, 19));
 	}
 
 

--- a/udo/base/dom/src/test/java/org/estatio/dom/PojoTester.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/PojoTester.java
@@ -76,7 +76,7 @@ public final class PojoTester {
        return new PojoTester(Mode.RELAXED);
    }
 
-	private final Map<Class<?>, FixtureDatumFactory<?>> fixtureDataByType = new HashMap<Class<?>, FixtureDatumFactory<?>>();
+	private final Map<Class<?>, FixtureDatumFactory<?>> fixtureDataByType = new HashMap<>();
 	private final AtomicInteger counter = new AtomicInteger();
 
 	private enum Mode {
@@ -204,7 +204,7 @@ public final class PojoTester {
 
 		FixtureDatumFactory<List<?>> listDatumFactory = new FixtureDatumFactory<List<?>>() {
 			public List<?> getNext() {
-				final List<String> list = new ArrayList<String>();
+				final List<String> list = new ArrayList<>();
 				list.add("element" + counter.getAndIncrement());
 				list.add("element" + counter.getAndIncrement());
 				list.add("element" + counter.getAndIncrement());
@@ -217,7 +217,7 @@ public final class PojoTester {
 
 		fixtureDataByType.put(Set.class, new FixtureDatumFactory<Set<?>>() {
 			public Set<?> getNext() {
-				final Set<String> list = new HashSet<String>();
+				final Set<String> list = new HashSet<>();
 				list.add("element" + counter.getAndIncrement());
 				list.add("element" + counter.getAndIncrement());
 				list.add("element" + counter.getAndIncrement());
@@ -226,7 +226,7 @@ public final class PojoTester {
 		});
 		fixtureDataByType.put(SortedSet.class, new FixtureDatumFactory<SortedSet<?>>() {
 		    public SortedSet<?> getNext() {
-		        final SortedSet<String> list = new TreeSet<String>();
+		        final SortedSet<String> list = new TreeSet<>();
 		        list.add("element" + counter.getAndIncrement());
 		        list.add("element" + counter.getAndIncrement());
 		        list.add("element" + counter.getAndIncrement());
@@ -246,7 +246,7 @@ public final class PojoTester {
 		if (fixtureData == null || fixtureData.length == 0) {
 			throw new IllegalArgumentException("Test data is mandatory");
 		}
-		return withFixture(new FixtureDatumFactory<T>(c, fixtureData));
+		return withFixture(new FixtureDatumFactory<>(c, fixtureData));
 	}
 
 	public <T> PojoTester withFixture(FixtureDatumFactory<T> factory) {
@@ -261,8 +261,8 @@ public final class PojoTester {
 	public void exercise(Object bean, FilterSet filterSet) {
 		// an array that fills as each property is tested, allowing
 		// subsequent properties to be tested against them
-		final List<Method> gettersDone = new ArrayList<Method>();
-		final List<TestException> problems = new ArrayList<TestException>();
+		final List<Method> gettersDone = new ArrayList<>();
+		final List<TestException> problems = new ArrayList<>();
 
 		final Map<String, Method> methods = getMethodsAsMap(bean);
 		for (Entry<String, Method> e : methods.entrySet()) {
@@ -307,7 +307,7 @@ public final class PojoTester {
 	}
 
 	private static Map<String, Method> getMethodsAsMap(Object bean) {
-		final Map<String, Method> methodMap = new HashMap<String, Method>();
+		final Map<String, Method> methodMap = new HashMap<>();
 		for (Method m : bean.getClass().getMethods()) {
 			methodMap.put(m.getName(), m);
 		}

--- a/udo/base/dom/src/test/java/org/estatio/dom/UdoDomainRepositoryAndFactoryTest.java
+++ b/udo/base/dom/src/test/java/org/estatio/dom/UdoDomainRepositoryAndFactoryTest.java
@@ -116,7 +116,7 @@ public class UdoDomainRepositoryAndFactoryTest {
         public void allMatches() {
 
             final String queryName = "foo";
-            final QueryDefault<SomeDomainObject> query = new QueryDefault<SomeDomainObject>(SomeDomainObject.class, queryName, "bar", 1);
+            final QueryDefault<SomeDomainObject> query = new QueryDefault<>(SomeDomainObject.class, queryName, "bar", 1);
 
             someDomainService.queryToReturn = query;
 
@@ -132,7 +132,7 @@ public class UdoDomainRepositoryAndFactoryTest {
         public void firstMatch() {
 
             final String queryName = "foo";
-            final QueryDefault<SomeDomainObject> query = new QueryDefault<SomeDomainObject>(SomeDomainObject.class, queryName, "bar", 1);
+            final QueryDefault<SomeDomainObject> query = new QueryDefault<>(SomeDomainObject.class, queryName, "bar", 1);
 
             someDomainService.queryToReturn = query;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.