### PR TITLE
Est 638 removal of @named annotation

### DIFF
--- a/estatioapp/dom/src/main/java/org/estatio/dom/agreement/Agreement.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/agreement/Agreement.java
@@ -46,7 +46,6 @@ import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -269,8 +268,8 @@ public abstract class Agreement
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     @Override
     public Agreement changeDates(
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End Date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return getChangeDates().changeDates(startDate, endDate);
     }
 
@@ -333,10 +332,10 @@ public abstract class Agreement
 
     @MemberOrder(name = "roles", sequence = "1")
     public Agreement newRole(
-            final @ParameterLayout(named = "Type") AgreementRoleType type,
+            final AgreementRoleType type,
             final Party party,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         createRole(type, party, startDate, endDate);
         return this;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRole.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRole.java
@@ -46,7 +46,6 @@ import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -169,7 +168,7 @@ public class AgreementRole
     @Getter @Setter
     private String externalReference;
 
-    public AgreementRole changeExternalReference(@ParameterLayout(named = "External reference") String externalReference) {
+    public AgreementRole changeExternalReference(String externalReference) {
         setExternalReference(externalReference);
         return this;
     }
@@ -193,8 +192,8 @@ public class AgreementRole
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     @Override
     public AgreementRole changeDates(
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End Date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         helper.changeDates(startDate, endDate);
         return this;
     }
@@ -284,8 +283,8 @@ public class AgreementRole
 
     public AgreementRole succeededBy(
             final Party party,
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End date") LocalDate endDate) {
+            final LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return helper.succeededBy(startDate, endDate, new SiblingFactory(this, party));
     }
 
@@ -314,8 +313,8 @@ public class AgreementRole
 
     public AgreementRole precededBy(
             final Party party,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @ParameterLayout(named = "End date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final LocalDate endDate) {
 
         return helper.precededBy(startDate, endDate, new SiblingFactory(this, party));
     }
@@ -354,10 +353,10 @@ public class AgreementRole
     // //////////////////////////////////////
 
     public AgreementRole addCommunicationChannel(
-            final @ParameterLayout(named = "Type") AgreementRoleCommunicationChannelType type,
+            final AgreementRoleCommunicationChannelType type,
             final CommunicationChannel communicationChannel,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         createAgreementRoleCommunicationChannel(type, communicationChannel, startDate, endDate);
         return this;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRoleCommunicationChannel.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRoleCommunicationChannel.java
@@ -190,8 +190,8 @@ public class AgreementRoleCommunicationChannel
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     @Override
     public AgreementRoleCommunicationChannel changeDates(
-            final @ParameterLayout(named = "Start Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         helper.changeDates(startDate, endDate);
         return this;
     }
@@ -287,8 +287,8 @@ public class AgreementRoleCommunicationChannel
 
     public AgreementRoleCommunicationChannel succeededBy(
             final CommunicationChannel communicationChannel,
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @ParameterLayout(named = "End date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return helper.succeededBy(startDate, endDate, new SiblingFactory(this,
                 communicationChannel));
     }
@@ -333,8 +333,8 @@ public class AgreementRoleCommunicationChannel
 
     public AgreementRoleCommunicationChannel precededBy(
             final CommunicationChannel communicationChannel,
-            final @ParameterLayout(named = "Start date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final LocalDate endDate) {
 
         return helper.precededBy(startDate, endDate, new SiblingFactory(this,
                 communicationChannel));

--- a/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRoleCommunicationChannel.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRoleCommunicationChannel.java
@@ -40,7 +40,6 @@ import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -398,8 +397,8 @@ public class AgreementRoleCommunicationChannel
 
     @ActionLayout(describedAs = "Change Communication Channel Type")
     public AgreementRoleCommunicationChannel changeType(
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Type") AgreementRoleCommunicationChannelType agreementRoleCommunicationChannelType) {
-        setType(agreementRoleCommunicationChannelType);
+            final @Parameter(optionality = Optionality.OPTIONAL) AgreementRoleCommunicationChannelType type) {
+        setType(type);
         return this;
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRoleRepository.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/agreement/AgreementRoleRepository.java
@@ -24,7 +24,6 @@ import org.joda.time.LocalDate;
 
 import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.NatureOfService;
-import org.apache.isis.applib.annotation.ParameterLayout;
 
 import org.estatio.dom.UdoDomainRepositoryAndFactory;
 import org.estatio.dom.party.Party;
@@ -46,8 +45,8 @@ public class AgreementRoleRepository extends UdoDomainRepositoryAndFactory<Agree
             final Agreement agreement,
             final Party party,
             final AgreementRoleType type,
-            final @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @ParameterLayout(named = "End Date") LocalDate endDate) {
+            final LocalDate startDate,
+            final LocalDate endDate) {
         AgreementRole agreementRole = newTransientInstance();
         persistIfNotAlready(agreementRole);
         agreementRole.setStartDate(startDate);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAsset.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAsset.java
@@ -40,7 +40,6 @@ import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -170,10 +169,10 @@ public abstract class FixedAsset<X extends FixedAsset<X>>
     private SortedSet<FixedAssetRole> roles = new TreeSet<>();
 
     public FixedAsset newRole(
-            final @ParameterLayout(named = "Type") FixedAssetRoleType type,
+            final FixedAssetRoleType type,
             final Party party,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         createRole(type, party, startDate, endDate);
         return this;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAssetRole.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAssetRole.java
@@ -35,7 +35,6 @@ import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -158,8 +157,8 @@ public class FixedAssetRole
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     @Override
     public FixedAssetRole changeDates(
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End Date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         helper.changeDates(startDate, endDate);
         return this;
     }
@@ -250,8 +249,8 @@ public class FixedAssetRole
 
     public FixedAssetRole succeededBy(
             final Party party,
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @ParameterLayout(named = "End date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return helper.succeededBy(startDate, endDate, new SiblingFactory(this, party));
     }
 
@@ -280,8 +279,8 @@ public class FixedAssetRole
 
     public FixedAssetRole precededBy(
             final Party party,
-            final @ParameterLayout(named = "Start date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final LocalDate endDate) {
 
         return helper.precededBy(startDate, endDate, new SiblingFactory(this, party));
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/Property.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/Property.java
@@ -159,7 +159,7 @@ public class Property
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     @ActionLayout(named = "Lookup")
     public FixedAsset lookupLocation(
-            final @ParameterLayout(named = "Address", describedAs = "Example: Herengracht 469, Amsterdam, NL") String address) {
+            final @ParameterLayout(describedAs = "Example: Herengracht 469, Amsterdam, NL") String address) {
         if (locationLookupService != null) {
             // TODO: service does not seem to be loaded in tests
             setLocation(locationLookupService.lookup(address));
@@ -182,10 +182,10 @@ public class Property
      */
     @Programmatic
     public FixedAssetRole addRoleIfDoesNotExist(
-            final @ParameterLayout(named = "party") Party party,
-            final @ParameterLayout(named = "type") FixedAssetRoleType type,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End Date") LocalDate endDate) {
+            final Party party,
+            final FixedAssetRoleType type,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
 
         FixedAssetRole role = fixedAssetRoleRepository.findRole(this, party, type, startDate, endDate);
         if (role == null) {
@@ -203,7 +203,7 @@ public class Property
 
     @Action(semantics = SemanticsOf.IDEMPOTENT_ARE_YOU_SURE)
     public Property dispose(
-            final @ParameterLayout(named = "Disposal date") LocalDate disposalDate
+            final LocalDate disposalDate
     ) {
         setDisposalDate(disposalDate);
         return this;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/Unit.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/Unit.java
@@ -33,7 +33,6 @@ import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -196,8 +195,8 @@ public class Unit
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     public Unit changeDates(
 
-            final @ParameterLayout(named = "Start Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return getChangeDates().changeDates(startDate, endDate);
     }
 
@@ -227,9 +226,9 @@ public class Unit
     // //////////////////////////////////////
 
     public Unit changeAsset(
-            final @ParameterLayout(named = "Name") String name,
-            final @ParameterLayout(named = "Type") UnitType type,
-            final @ParameterLayout(named = "External Reference") @Parameter(optionality = Optionality.OPTIONAL) String externalReference) {
+            final String name,
+            final UnitType type,
+            final @Parameter(optionality = Optionality.OPTIONAL) String externalReference) {
         setName(name);
         setExternalReference(externalReference);
         return this;
@@ -250,11 +249,11 @@ public class Unit
     // ///////////////////////////////////////
 
     public Unit changeAreas(
-            final @ParameterLayout(named = "Area") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal area,
-            final @ParameterLayout(named = "Storage Area") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal storageArea,
-            final @ParameterLayout(named = "Sales Area") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal salesArea,
-            final @ParameterLayout(named = "Mezzanine Area") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal mezzanineArea,
-            final @ParameterLayout(named = "Dehors Area") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal dehorsArea) {
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal area,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal storageArea,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal salesArea,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal mezzanineArea,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal dehorsArea) {
         setArea(area);
         setStorageArea(storageArea);
         setSalesArea(salesArea);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/UnitMenu.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/UnitMenu.java
@@ -80,8 +80,8 @@ public class UnitMenu extends UdoDomainService<UnitMenu> {
     )
     @MemberOrder(sequence = "2")
     public List<Unit> findUnits(
-            final @ParameterLayout(named = "Reference or Name", describedAs = "May include wildcards '*' and '?'") String referenceOrName,
-            final @ParameterLayout(named = "Include terminated") boolean includeTerminated) {
+            final @ParameterLayout(describedAs = "May include wildcards '*' and '?'") String referenceOrName,
+            final boolean includeTerminated) {
         return unitRepository.findUnits(referenceOrName, includeTerminated);
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/registration/FixedAssetRegistration.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/registration/FixedAssetRegistration.java
@@ -33,7 +33,6 @@ import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -129,8 +128,8 @@ public abstract class FixedAssetRegistration
     }
 
     public FixedAssetRegistration changeDates(
-            final @ParameterLayout(named = "Start date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         if (getPrevious() != null) {
             getPrevious().getChangeDates().changeDates(getPrevious().getStartDate(), startDate.minusDays(1));
         }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/bankmandate/BankMandate.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/bankmandate/BankMandate.java
@@ -18,21 +18,33 @@
  */
 package org.estatio.dom.bankmandate;
 
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.isis.applib.annotation.*;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.jdo.annotations.InheritanceStrategy;
+
+import org.joda.time.LocalDate;
+
+import org.apache.isis.applib.annotation.ActionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
+import org.apache.isis.applib.annotation.Editing;
+import org.apache.isis.applib.annotation.Optionality;
+import org.apache.isis.applib.annotation.Parameter;
+import org.apache.isis.applib.annotation.Property;
+import org.apache.isis.applib.annotation.PropertyLayout;
+import org.apache.isis.applib.annotation.Where;
+
+import org.isisaddons.module.security.dom.tenancy.ApplicationTenancy;
+
 import org.estatio.dom.agreement.Agreement;
 import org.estatio.dom.apptenancy.WithApplicationTenancyPathPersisted;
 import org.estatio.dom.apptenancy.WithApplicationTenancyProperty;
 import org.estatio.dom.financial.FinancialAccount;
 import org.estatio.dom.financial.bankaccount.BankAccount;
 import org.estatio.dom.financial.bankaccount.BankAccounts;
-import org.isisaddons.module.security.dom.tenancy.ApplicationTenancy;
-import org.joda.time.LocalDate;
 
-import javax.inject.Inject;
-import javax.jdo.annotations.InheritanceStrategy;
-import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
 
 @javax.jdo.annotations.PersistenceCapable
 // identityType=IdentityType.DATASTORE inherited from superclass
@@ -141,8 +153,8 @@ public class BankMandate
     }
 
     public BankMandate change(
-            final @ParameterLayout(named = "Name") @Parameter(optionality = Optionality.OPTIONAL) String name,
-            final @ParameterLayout(named = "Sepa Mandate Identifier") @Parameter(optionality = Optionality.OPTIONAL) String SepaMendateIdentifier,
+            final @Parameter(optionality = Optionality.OPTIONAL) String name,
+            final @Parameter(optionality = Optionality.OPTIONAL) String SepaMendateIdentifier,
             final @Parameter(optionality = Optionality.OPTIONAL) SequenceType sequenceType,
             final @Parameter(optionality = Optionality.OPTIONAL) Scheme scheme) {
         setName(name);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/allocation/BudgetItemAllocation.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/allocation/BudgetItemAllocation.java
@@ -31,7 +31,6 @@ import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.MemberOrder;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.RestrictTo;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -108,7 +107,7 @@ public class BudgetItemAllocation extends EstatioDomainObject<BudgetItemAllocati
     private KeyTable keyTable;
 
     @ActionLayout(hidden = Where.EVERYWHERE)
-    public BudgetItemAllocation changeKeyTable(final @ParameterLayout(named = "KeyTable") KeyTable keyTable) {
+    public BudgetItemAllocation changeKeyTable(final KeyTable keyTable) {
         setKeyTable(keyTable);
         return this;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/keyitem/KeyItem.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/budgeting/keyitem/KeyItem.java
@@ -30,7 +30,6 @@ import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.ActionLayout;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.RestrictTo;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -120,7 +119,7 @@ public class KeyItem extends EstatioDomainObject<KeyItem>
     private BigDecimal value;
 
     @ActionLayout(hidden = Where.EVERYWHERE)
-    public KeyItem changeValue(final @ParameterLayout(named = "Key value") BigDecimal keyValue) {
+    public KeyItem changeValue(final BigDecimal keyValue) {
         setValue(keyValue.setScale(getKeyTable().getPrecision(), BigDecimal.ROUND_HALF_UP));
         return this;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/charge/Charge.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/charge/Charge.java
@@ -26,7 +26,6 @@ import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.Where;
@@ -146,12 +145,12 @@ public class Charge
     // //////////////////////////////////////
 
     public Charge change(
-            final @ParameterLayout(named = "Name") String name,
-            final @ParameterLayout(named = "Tax") @Parameter(optionality = Optionality.OPTIONAL) Tax tax,
-            final @ParameterLayout(named = "Description") String description,
-            final @ParameterLayout(named = "Group") ChargeGroup group,
-            final @ParameterLayout(named = "External Reference") @Parameter(optionality = Optionality.OPTIONAL) String externalReference,
-            final @ParameterLayout(named = "Sort Order") @Parameter(optionality = Optionality.OPTIONAL) String sortOrder) {
+            final String name,
+            final @Parameter(optionality = Optionality.OPTIONAL) Tax tax,
+            final String description,
+            final ChargeGroup group,
+            final @Parameter(optionality = Optionality.OPTIONAL) String externalReference,
+            final @Parameter(optionality = Optionality.OPTIONAL) String sortOrder) {
 
         setName(name);
         setTax(tax);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/CommunicationChannelContributions.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/CommunicationChannelContributions.java
@@ -28,7 +28,6 @@ import org.apache.isis.applib.annotation.Contributed;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.RenderType;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
@@ -71,13 +70,13 @@ public abstract class CommunicationChannelContributions extends UdoDomainService
             final CommunicationChannelType type,
             final Country country,
             final @Parameter(optionality = Optionality.OPTIONAL) State state,
-            final @ParameterLayout(named = "Address line 1") String address1,
-            final @ParameterLayout(named = "Address line 2") @Parameter(optionality = Optionality.OPTIONAL) String address2,
-            final @ParameterLayout(named = "Address line 3") @Parameter(optionality = Optionality.OPTIONAL) String address3,
+            final String addressLine1,
+            final @Parameter(optionality = Optionality.OPTIONAL) String addressLine2,
+            final @Parameter(optionality = Optionality.OPTIONAL) String addressLine3,
             final String postalCode,
             final String city
             ) {
-        communicationChannels.newPostal(owner, type, address1, address2, null, postalCode, city, state, country);
+        communicationChannels.newPostal(owner, type, addressLine1, addressLine2, null, postalCode, city, state, country);
         return owner;
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/CommunicationChannelContributions.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/CommunicationChannelContributions.java
@@ -67,15 +67,15 @@ public abstract class CommunicationChannelContributions extends UdoDomainService
     // CHECKSTYLE.OFF: ParameterNumber - Wicket viewer does not support
     // aggregate value types
     public CommunicationChannelOwner newPostal(
-            final @ParameterLayout(named = "Owner") CommunicationChannelOwner owner,
-            final @ParameterLayout(named = "Type") CommunicationChannelType type,
+            final CommunicationChannelOwner owner,
+            final CommunicationChannelType type,
             final Country country,
             final @Parameter(optionality = Optionality.OPTIONAL) State state,
             final @ParameterLayout(named = "Address line 1") String address1,
             final @ParameterLayout(named = "Address line 2") @Parameter(optionality = Optionality.OPTIONAL) String address2,
             final @ParameterLayout(named = "Address line 3") @Parameter(optionality = Optionality.OPTIONAL) String address3,
-            final @ParameterLayout(named = "Postal Code") String postalCode,
-            final @ParameterLayout(named = "City") String city
+            final String postalCode,
+            final String city
             ) {
         communicationChannels.newPostal(owner, type, address1, address2, null, postalCode, city, state, country);
         return owner;
@@ -114,9 +114,9 @@ public abstract class CommunicationChannelContributions extends UdoDomainService
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @ActionLayout(contributed = Contributed.AS_ACTION)
     public CommunicationChannelOwner newEmail(
-            final @ParameterLayout(named = "Owner") CommunicationChannelOwner owner,
-            final @ParameterLayout(named = "Type") CommunicationChannelType type,
-            final @ParameterLayout(named = "Address") String address) {
+            final CommunicationChannelOwner owner,
+            final CommunicationChannelType type,
+            final String address) {
         communicationChannels.newEmail(owner, type, address);
         return owner;
     }
@@ -143,9 +143,9 @@ public abstract class CommunicationChannelContributions extends UdoDomainService
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @ActionLayout(named = "New Phone/Fax", contributed = Contributed.AS_ACTION)
     public CommunicationChannelOwner newPhoneOrFax(
-            final @ParameterLayout(named = "Owner") CommunicationChannelOwner owner,
-            final @ParameterLayout(named = "Type") CommunicationChannelType type,
-            final @ParameterLayout(named = "Number") String number) {
+            final CommunicationChannelOwner owner,
+            final CommunicationChannelType type,
+            final String number) {
         communicationChannels.newPhoneOrFax(owner, type, number);
         return owner;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/EmailAddress.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/EmailAddress.java
@@ -28,7 +28,6 @@ import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 
 import org.estatio.dom.JdoColumnLength;
@@ -58,8 +57,8 @@ public class EmailAddress extends CommunicationChannel {
     private String emailAddress;
 
     public EmailAddress changeEmailAddress(
-            final @ParameterLayout(named = "Email Address") @Parameter(regexPattern = RegexValidation.CommunicationChannel.EMAIL, regexPatternReplacement = RegexValidation.CommunicationChannel.EMAIL_DESCRIPTION) String address) {
-        setEmailAddress(address);
+            final @Parameter(regexPattern = RegexValidation.CommunicationChannel.EMAIL, regexPatternReplacement = RegexValidation.CommunicationChannel.EMAIL_DESCRIPTION) String emailAddress) {
+        setEmailAddress(emailAddress);
 
         return this;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/PhoneOrFaxNumber.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/PhoneOrFaxNumber.java
@@ -29,7 +29,6 @@ import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 
 import org.estatio.dom.JdoColumnLength;
@@ -60,7 +59,7 @@ public class PhoneOrFaxNumber extends CommunicationChannel {
 
     @ActionLayout(named = "Change Number")
     public PhoneOrFaxNumber changePhoneOrFaxNumber(
-            final @ParameterLayout(named = "Phone Number") @Parameter(regexPattern = RegexValidation.CommunicationChannel.PHONENUMBER, regexPatternReplacement = RegexValidation.CommunicationChannel.PHONENUMBER_DESCRIPTION) String phoneNumber) {
+            final @Parameter(regexPattern = RegexValidation.CommunicationChannel.PHONENUMBER, regexPatternReplacement = RegexValidation.CommunicationChannel.PHONENUMBER_DESCRIPTION) String phoneNumber) {
         setPhoneNumber(phoneNumber);
 
         return this;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/PostalAddress.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/communicationchannel/PostalAddress.java
@@ -31,7 +31,6 @@ import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.util.TitleBuffer;
@@ -161,14 +160,14 @@ public class PostalAddress extends CommunicationChannel {
     }
 
     public PostalAddress changePostalAddress(
-            final @ParameterLayout(named = "Address Line 1") String address1,
-            final @ParameterLayout(named = "Address Line 2") @Parameter(optionality = Optionality.OPTIONAL) String address2,
-            final @ParameterLayout(named = "Address Line 3") @Parameter(optionality = Optionality.OPTIONAL) String address3,
-            final @ParameterLayout(named = "City") String city,
-            final @ParameterLayout(named = "Postal Code") String postalCode) {
-        setAddress1(address1);
-        setAddress2(address2);
-        setAddress3(address3);
+            final String addressLine1,
+            final @Parameter(optionality = Optionality.OPTIONAL) String addressLine2,
+            final @Parameter(optionality = Optionality.OPTIONAL) String addressLine3,
+            final String city,
+            final String postalCode) {
+        setAddress1(addressLine1);
+        setAddress2(addressLine2);
+        setAddress3(addressLine3);
         setCity(city);
         setPostalCode(postalCode);
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/document/Document.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/document/Document.java
@@ -28,7 +28,6 @@ import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.Where;
 import org.apache.isis.applib.services.clock.ClockService;
@@ -156,8 +155,8 @@ public class Document implements Comparable<Document>, WithIntervalMutable<Docum
 
     @Override
     public Document changeDates(
-            final @ParameterLayout(named = "Start date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "Start date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return getHelper().changeDates(startDate, endDate);
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/event/Event.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/event/Event.java
@@ -195,7 +195,7 @@ public class Event
         };
     }
 
-    public Event changeNotes(final @ParameterLayout(named = "Notes", multiLine = NUMBER_OF_LINES) String notes) {
+    public Event changeNotes(final @ParameterLayout(multiLine = NUMBER_OF_LINES) String notes) {
         setNotes(notes);
 
         return this;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/geography/States.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/geography/States.java
@@ -26,12 +26,11 @@ import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.DomainServiceLayout;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
-import org.estatio.dom.UdoDomainRepositoryAndFactory;
 import org.estatio.dom.RegexValidation;
+import org.estatio.dom.UdoDomainRepositoryAndFactory;
 
 @DomainService(repositoryFor = State.class)
 @DomainServiceLayout(
@@ -50,8 +49,8 @@ public class States
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @MemberOrder(sequence = "1")
     public State newState(
-            final @ParameterLayout(named = "Reference") @Parameter(regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String reference,
-            final @ParameterLayout(named = "Name") String name,
+            final @Parameter(regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String reference,
+            final String name,
             final Country country) {
         final State state = newTransientInstance();
         return createState(reference, name, country, state);
@@ -77,7 +76,7 @@ public class States
     }
 
     @Programmatic
-    public State findState(final @ParameterLayout(named = "Reference") String reference) {
+    public State findState(final String reference) {
         return firstMatch("findByReference", "reference", reference);
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/guarantee/Guarantee.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/guarantee/Guarantee.java
@@ -166,8 +166,8 @@ public class Guarantee
     // //////////////////////////////////////
 
     public Guarantee terminate(
-            final @ParameterLayout(named = "Termination date") LocalDate terminationDate,
-            final @ParameterLayout(named = "Description") String description) {
+            final LocalDate terminationDate,
+            final String description) {
         setTerminationDate(terminationDate);
         BigDecimal balance = financialAccount.getBalance();
         if (balance.compareTo(BigDecimal.ZERO) != 0) {
@@ -183,7 +183,7 @@ public class Guarantee
     private BigDecimal contractualAmount;
 
     public Guarantee changeContractualAmount(
-            final @ParameterLayout(named = "New contractual amount") BigDecimal newContractualAmount) {
+            final BigDecimal newContractualAmount) {
         setContractualAmount(newContractualAmount);
         return this;
     }
@@ -193,9 +193,9 @@ public class Guarantee
     }
 
     public Guarantee change(
-            final @ParameterLayout(named = "Name") String name,
-            final @ParameterLayout(named = "Description", multiLine = 3) @Parameter(optionality = Optionality.OPTIONAL) String description,
-            final @ParameterLayout(named = "Comments", multiLine = 3) String comments) {
+            final String name,
+            final @ParameterLayout(multiLine = 3) @Parameter(optionality = Optionality.OPTIONAL) String description,
+            final @ParameterLayout(multiLine = 3) String comments) {
         setName(name);
         setDescription(description);
         setComments(comments);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/index/IndexRepository.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/index/IndexRepository.java
@@ -26,7 +26,6 @@ import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.NatureOfService;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
@@ -72,7 +71,7 @@ public class IndexRepository extends UdoDomainRepositoryAndFactory<Index> implem
 
     @Programmatic
     @Override
-    public Index findByReference(final @ParameterLayout(named = "Reference") String reference) {
+    public Index findByReference(final String reference) {
         return firstMatch("findByReference", "reference", reference);
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/index/IndexValueRepository.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/index/IndexValueRepository.java
@@ -28,7 +28,6 @@ import org.joda.time.LocalDate;
 
 import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.NatureOfService;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.services.eventbus.EventBusService;
 import org.apache.isis.applib.services.queryresultscache.QueryResultsCache;
 
@@ -80,7 +79,7 @@ public class IndexValueRepository
 
     public IndexValue findByIndexAndStartDate(
             final Index index,
-            final @ParameterLayout(named = "Start Date") LocalDate startDate) {
+            final LocalDate startDate) {
         return queryResultsCache.execute(
                 new Callable<IndexValue>() {
                     @Override

--- a/estatioapp/dom/src/main/java/org/estatio/dom/invoice/Invoice.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/invoice/Invoice.java
@@ -43,7 +43,6 @@ import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.InvokeOn;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -289,7 +288,7 @@ public class Invoice
     private LocalDate dueDate;
 
     public void changeDueDate(
-            final @ParameterLayout(named = "Due date") LocalDate dueDate) {
+            final LocalDate dueDate) {
         setDueDate(dueDate);
     }
 
@@ -328,7 +327,7 @@ public class Invoice
 
     public Invoice changePaymentMethod(
             final PaymentMethod paymentMethod,
-            final @ParameterLayout(named = "Reason") String reason) {
+            final String reason) {
         setPaymentMethod(paymentMethod);
         return this;
     }
@@ -487,7 +486,7 @@ public class Invoice
 
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT_ARE_YOU_SURE)
     public Invoice invoice(
-            final @ParameterLayout(named = "Invoice date") LocalDate invoiceDate) {
+            final LocalDate invoiceDate) {
 
         final Numerator numerator = estatioNumeratorRepository.findInvoiceNumberNumerator(getFixedAsset(), getApplicationTenancy());
         setInvoiceNumber(numerator.nextIncrementStr());
@@ -543,10 +542,10 @@ public class Invoice
 
     public InvoiceItem newItem(
             final Charge charge,
-            final @ParameterLayout(named = "Quantity") BigDecimal quantity,
-            final @ParameterLayout(named = "Net amount") BigDecimal netAmount,
-            final @ParameterLayout(named = "Start date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final BigDecimal quantity,
+            final BigDecimal netAmount,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         InvoiceItem invoiceItem = invoiceItems.newInvoiceItem(this, getDueDate());
         invoiceItem.setQuantity(quantity);
         invoiceItem.setCharge(charge);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/invoice/InvoiceItem.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/invoice/InvoiceItem.java
@@ -202,7 +202,7 @@ public abstract class InvoiceItem
     private String description;
 
     public InvoiceItem changeDescription(
-            final @ParameterLayout(named = "Description", multiLine = 3) String description) {
+            final @ParameterLayout(multiLine = 3) String description) {
         setDescription(description);
         return this;
     }
@@ -255,8 +255,8 @@ public abstract class InvoiceItem
     private LocalDate effectiveEndDate;
 
     public InvoiceItem changeEffectiveDates(
-            final @ParameterLayout(named = "Effective start date") LocalDate effectiveStartDate,
-            final @ParameterLayout(named = "Effective end date") LocalDate effectiveEndDate) {
+            final LocalDate effectiveStartDate,
+            final LocalDate effectiveEndDate) {
         setEffectiveStartDate(effectiveStartDate);
         setEffectiveEndDate(effectiveEndDate);
         return this;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/invoice/Invoices.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/invoice/Invoices.java
@@ -28,7 +28,6 @@ import org.apache.isis.applib.annotation.Contributed;
 import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.DomainServiceLayout;
 import org.apache.isis.applib.annotation.MemberOrder;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.RestrictTo;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -166,8 +165,8 @@ public class Invoices extends UdoDomainRepositoryAndFactory<Invoice> {
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @MemberOrder(sequence = "1")
     public Invoice newInvoiceForLease(
-            final @ParameterLayout(named = "Lease") Lease lease,
-            final @ParameterLayout(named = "Due date") LocalDate dueDate,
+            final Lease lease,
+            final LocalDate dueDate,
             final PaymentMethod paymentMethod,
             final Currency currency,
             final ApplicationTenancy applicationTenancy) {
@@ -190,11 +189,11 @@ public class Invoices extends UdoDomainRepositoryAndFactory<Invoice> {
     @Programmatic
     public Invoice newInvoice(
             final ApplicationTenancy applicationTenancy,
-            final @ParameterLayout(named = "Seller") Party seller,
-            final @ParameterLayout(named = "Buyer") Party buyer,
+            final Party seller,
+            final Party buyer,
             final PaymentMethod paymentMethod,
             final Currency currency,
-            final @ParameterLayout(named = "Due date") LocalDate dueDate,
+            final LocalDate dueDate,
             final Lease lease,
             final String interactionId
     ) {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/Lease.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/Lease.java
@@ -18,17 +18,53 @@
  */
 package org.estatio.dom.lease;
 
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.inject.Inject;
+import javax.jdo.annotations.IdentityType;
+import javax.jdo.annotations.InheritanceStrategy;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import lombok.Getter;
-import lombok.Setter;
+
 import org.apache.commons.lang3.ObjectUtils;
-import org.apache.isis.applib.annotation.*;
+import org.joda.time.LocalDate;
+import org.joda.time.Period;
+import org.joda.time.PeriodType;
+
+import org.apache.isis.applib.annotation.Action;
+import org.apache.isis.applib.annotation.BookmarkPolicy;
+import org.apache.isis.applib.annotation.CollectionLayout;
+import org.apache.isis.applib.annotation.DomainObject;
+import org.apache.isis.applib.annotation.DomainObjectLayout;
+import org.apache.isis.applib.annotation.Editing;
+import org.apache.isis.applib.annotation.InvokeOn;
+import org.apache.isis.applib.annotation.Optionality;
+import org.apache.isis.applib.annotation.Parameter;
+import org.apache.isis.applib.annotation.Programmatic;
+import org.apache.isis.applib.annotation.PropertyLayout;
+import org.apache.isis.applib.annotation.RenderType;
+import org.apache.isis.applib.annotation.RestrictTo;
+import org.apache.isis.applib.annotation.SemanticsOf;
+import org.apache.isis.applib.annotation.Where;
 import org.apache.isis.applib.services.eventbus.ActionDomainEvent;
+
+import org.isisaddons.module.security.dom.tenancy.ApplicationTenancy;
+
 import org.estatio.dom.EstatioUserRole;
 import org.estatio.dom.JdoColumnLength;
 import org.estatio.dom.RegexValidation;
-import org.estatio.dom.agreement.*;
+import org.estatio.dom.agreement.Agreement;
+import org.estatio.dom.agreement.AgreementRole;
+import org.estatio.dom.agreement.AgreementRoleCommunicationChannel;
+import org.estatio.dom.agreement.AgreementRoleCommunicationChannelTypeRepository;
+import org.estatio.dom.agreement.AgreementRoleType;
+import org.estatio.dom.agreement.AgreementType;
 import org.estatio.dom.apptenancy.EstatioApplicationTenancyRepository;
 import org.estatio.dom.apptenancy.WithApplicationTenancyPathPersisted;
 import org.estatio.dom.apptenancy.WithApplicationTenancyProperty;
@@ -36,7 +72,11 @@ import org.estatio.dom.asset.Property;
 import org.estatio.dom.asset.Unit;
 import org.estatio.dom.asset.UnitMenu;
 import org.estatio.dom.asset.UnitRepository;
-import org.estatio.dom.bankmandate.*;
+import org.estatio.dom.bankmandate.BankMandate;
+import org.estatio.dom.bankmandate.BankMandateConstants;
+import org.estatio.dom.bankmandate.BankMandateRepository;
+import org.estatio.dom.bankmandate.Scheme;
+import org.estatio.dom.bankmandate.SequenceType;
 import org.estatio.dom.charge.Charge;
 import org.estatio.dom.communicationchannel.CommunicationChannels;
 import org.estatio.dom.financial.FinancialAccount;
@@ -50,16 +90,9 @@ import org.estatio.dom.utils.JodaPeriodUtils;
 import org.estatio.dom.utils.StringUtils;
 import org.estatio.dom.valuetypes.LocalDateInterval;
 import org.estatio.services.clock.ClockService;
-import org.isisaddons.module.security.dom.tenancy.ApplicationTenancy;
-import org.joda.time.LocalDate;
-import org.joda.time.Period;
-import org.joda.time.PeriodType;
 
-import javax.inject.Inject;
-import javax.jdo.annotations.IdentityType;
-import javax.jdo.annotations.InheritanceStrategy;
-import java.math.BigInteger;
-import java.util.*;
+import lombok.Getter;
+import lombok.Setter;
 
 @javax.jdo.annotations.PersistenceCapable(identityType = IdentityType.DATASTORE)
 @javax.jdo.annotations.Inheritance(
@@ -233,8 +266,8 @@ public class Lease
     private LeaseType leaseType;
 
     public Lease change(
-            final @ParameterLayout(named = "Name") String name,
-            final @ParameterLayout(named = "Lease Type") @Parameter(optionality = Optionality.OPTIONAL) LeaseType leaseType) {
+            final String name,
+            final @Parameter(optionality = Optionality.OPTIONAL) LeaseType leaseType) {
         setName(name);
         setLeaseType(leaseType);
         return this;
@@ -298,8 +331,8 @@ public class Lease
 
     @Action(domainEvent = ChangeDatesEvent.class)
     public Lease changeTenancyDates(
-            final @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         setTenancyStartDate(startDate);
         setTenancyEndDate(endDate);
 
@@ -348,8 +381,8 @@ public class Lease
      * @return
      */
     public Occupancy newOccupancy(
-            final @ParameterLayout(named = "Start date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "Unit") Unit unit) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final Unit unit) {
         Occupancy occupancy = occupanciesRepo.newOccupancy(this, unit, startDate);
         occupancies.add(occupancy);
         return occupancy;
@@ -559,9 +592,9 @@ public class Lease
 
     public Lease newMandate(
             final BankAccount bankAccount,
-            final @ParameterLayout(named = "Reference") @Parameter(regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String reference,
-            final @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate,
+            final @Parameter(regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String reference,
+            final LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate,
             final @Parameter(optionality = Optionality.OPTIONAL) SequenceType sequenceType,
             final @Parameter(optionality = Optionality.OPTIONAL) Scheme scheme,
             final @Parameter(optionality = Optionality.OPTIONAL) LocalDate signatureDate) {
@@ -709,7 +742,7 @@ public class Lease
     // //////////////////////////////////////
 
     @Action(domainEvent = Lease.SuspendAllEvent.class)
-    public Lease suspendAll(final @ParameterLayout(named = "Reason") String reason) {
+    public Lease suspendAll(final String reason) {
         for (LeaseItem item : getItems()) {
             item.suspend(reason);
         }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseItem.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseItem.java
@@ -45,7 +45,6 @@ import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -199,7 +198,7 @@ public class LeaseItem
     // //////////////////////////////////////
 
     @Action(domainEvent = LeaseItem.SuspendEvent.class)
-    public LeaseItem suspend(final @ParameterLayout(named = "Reason") String reason) {
+    public LeaseItem suspend(final String reason) {
         setStatus(LeaseItemStatus.SUSPENDED);
         return this;
     }
@@ -209,7 +208,7 @@ public class LeaseItem
     }
 
     @Action(domainEvent = LeaseItem.ResumeEvent.class)
-    public LeaseItem resume(final @ParameterLayout(named = "Reason") String reason) {
+    public LeaseItem resume(final String reason) {
         doResume();
         return this;
     }
@@ -318,8 +317,8 @@ public class LeaseItem
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     @Override
     public LeaseItem changeDates(
-            final @ParameterLayout(named = "Start Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return getChangeDates().changeDates(startDate, endDate);
     }
 
@@ -349,7 +348,7 @@ public class LeaseItem
     // //////////////////////////////////////
 
     public LeaseItem copy(
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
+            final LocalDate startDate,
             final InvoicingFrequency invoicingFrequency,
             final PaymentMethod paymentMethod,
             final Charge charge
@@ -381,7 +380,7 @@ public class LeaseItem
     // //////////////////////////////////////
 
     public LeaseItem terminate(
-            final @ParameterLayout(named = "End date") LocalDate endDate) {
+            final LocalDate endDate) {
         this.changeDates(getStartDate(), endDate);
         return this;
     }
@@ -458,7 +457,7 @@ public class LeaseItem
 
     public LeaseItem changePaymentMethod(
             final PaymentMethod paymentMethod,
-            final @ParameterLayout(named = "Reason") String reason) {
+            final String reason) {
         setPaymentMethod(paymentMethod);
         return this;
     }
@@ -474,14 +473,14 @@ public class LeaseItem
 
     public LeaseItem overrideTax(
             final Tax tax,
-            final @ParameterLayout(named = "Reason") String reason) {
+            final String reason) {
         setTax(tax);
         return this;
     }
 
     public Tax default0OverrideTax(
             final Tax tax,
-            final @ParameterLayout(named = "Reason") String reason) {
+            final String reason) {
         return getTax();
     }
 
@@ -492,7 +491,7 @@ public class LeaseItem
     // //////////////////////////////////////
 
     public LeaseItem cancelOverrideTax(
-            final @ParameterLayout(named = "Reason") String reason) {
+            final String reason) {
         setTax(null);
         return this;
     }
@@ -558,8 +557,8 @@ public class LeaseItem
     // //////////////////////////////////////
 
     public LeaseTerm newTerm(
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @ParameterLayout(named = "End date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return leaseTerms.newLeaseTerm(this, lastInChain(), startDate, endDate);
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTerm.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTerm.java
@@ -45,7 +45,6 @@ import org.apache.isis.applib.annotation.InvokeOn;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -216,10 +215,10 @@ public abstract class LeaseTerm
     @Override
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     public LeaseTerm changeDates(
-            final @ParameterLayout(named = "Start Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate newStartDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate newEndDate) {
-        modifyStartDate(newStartDate);
-        modifyEndDate(newEndDate);
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+        modifyStartDate(startDate);
+        modifyEndDate(endDate);
         return this;
     }
 
@@ -418,13 +417,13 @@ public abstract class LeaseTerm
     // //////////////////////////////////////
 
     public LeaseTerm createNext(
-            final @ParameterLayout(named = "Start date") LocalDate nextStartDate,
-            final @ParameterLayout(named = "End date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate nextEndDate) {
+            final LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         LeaseTerm nextTerm = getNext();
         if (nextTerm != null) {
             return nextTerm;
         }
-        nextTerm = terms.newLeaseTerm(getLeaseItem(), this, nextStartDate, nextEndDate);
+        nextTerm = terms.newLeaseTerm(getLeaseItem(), this, startDate, endDate);
         return nextTerm;
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForIndexable.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForIndexable.java
@@ -33,16 +33,15 @@ import org.joda.time.LocalDate;
 
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 
 import org.estatio.dom.JdoColumnScale;
 import org.estatio.dom.index.Index;
 import org.estatio.dom.index.IndexRepository;
+import org.estatio.dom.lease.indexation.Indexable;
 import org.estatio.dom.lease.indexation.IndexationCalculationMethod;
 import org.estatio.dom.lease.indexation.IndexationMethod;
 import org.estatio.dom.lease.indexation.IndexationService;
-import org.estatio.dom.lease.indexation.Indexable;
 import org.estatio.dom.utils.MathUtils;
 
 import lombok.Getter;
@@ -118,10 +117,10 @@ public class LeaseTermForIndexable extends LeaseTerm implements Indexable {
     public LeaseTermForIndexable changeParameters(
             final IndexationMethod indexationMethod,
             final Index index,
-            final @ParameterLayout(named = "Base index date") LocalDate baseIndexDate,
-            final @ParameterLayout(named = "Next index date") LocalDate nextIndexDate,
-            final @ParameterLayout(named = "Levelling percentage") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal levellingPercentage,
-            final @ParameterLayout(named = "Effective date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate effectiveDate
+            final LocalDate baseIndexDate,
+            final LocalDate nextIndexDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal levellingPercentage,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate effectiveDate
     ) {
         setIndexationMethod(indexationMethod);
         setIndex(index);
@@ -213,8 +212,8 @@ public class LeaseTermForIndexable extends LeaseTerm implements Indexable {
     // //////////////////////////////////////
 
     public LeaseTermForIndexable changeValues(
-            final @ParameterLayout(named = "Base value") BigDecimal baseValue,
-            final @ParameterLayout(named = "Settled value") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal settledValue) {
+            final BigDecimal baseValue,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal settledValue) {
         setBaseValue(baseValue);
         setSettledValue(settledValue);
         setIndexedValue(null);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTax.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTax.java
@@ -138,10 +138,10 @@ public class LeaseTermForTax extends LeaseTerm {
 
     public LeaseTermForTax changeInvoicing(
             final BigDecimal recoverablePercentage,
-            final @ParameterLayout(named = "Override recoverable amount") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal overrideTaxValue) {
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal overrideRecoverableAmount) {
         setRecoverablePercentage(recoverablePercentage);
-        setTaxValue(overrideTaxValue);
-        setOverrideTaxValue(overrideTaxValue != null);
+        setTaxValue(overrideRecoverableAmount);
+        setOverrideTaxValue(overrideRecoverableAmount != null);
         return this;
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTax.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTax.java
@@ -68,8 +68,8 @@ public class LeaseTermForTax extends LeaseTerm {
     }
 
     public LeaseTermForTax changeTax(
-            final @ParameterLayout(named = "Tax percentage") BigDecimal taxPercentage,
-            final @ParameterLayout(named = "Override payable value") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal overridePayableValue) {
+            final BigDecimal taxPercentage,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal overridePayableValue) {
         setTaxPercentage(taxPercentage);
         setPayableValue(overridePayableValue);
         setOverridePayableValue(overridePayableValue != null);
@@ -100,7 +100,7 @@ public class LeaseTermForTax extends LeaseTerm {
 
     @Action(semantics = SemanticsOf.IDEMPOTENT_ARE_YOU_SURE)
     public LeaseTermForTax changePaymentDate(
-            final @ParameterLayout(named = "Payment date") LocalDate paymentDate) {
+            final LocalDate paymentDate) {
         setPaymentDate(paymentDate);
         return this;
     }
@@ -137,7 +137,7 @@ public class LeaseTermForTax extends LeaseTerm {
     // //////////////////////////////////////
 
     public LeaseTermForTax changeInvoicing(
-            final @ParameterLayout(named = "Recoverable percentage") BigDecimal recoverablePercentage,
+            final BigDecimal recoverablePercentage,
             final @ParameterLayout(named = "Override recoverable amount") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal overrideTaxValue) {
         setRecoverablePercentage(recoverablePercentage);
         setTaxValue(overrideTaxValue);
@@ -227,11 +227,11 @@ public class LeaseTermForTax extends LeaseTerm {
     // //////////////////////////////////////
 
     public LeaseTermForTax changeRegistration(
-            final @ParameterLayout(named = "Registration date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate registrationDate,
-            final @ParameterLayout(named = "Registration number") @Parameter(optionality = Optionality.OPTIONAL) String registrationNumber,
-            final @ParameterLayout(named = "Office code") @Parameter(optionality = Optionality.OPTIONAL) String officeCode,
-            final @ParameterLayout(named = "Office name") @Parameter(optionality = Optionality.OPTIONAL) String officeName,
-            final @ParameterLayout(named = "Description", multiLine = 3) @Parameter(optionality = Optionality.OPTIONAL) String description
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate registrationDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) String registrationNumber,
+            final @Parameter(optionality = Optionality.OPTIONAL) String officeCode,
+            final @Parameter(optionality = Optionality.OPTIONAL) String officeName,
+            final @ParameterLayout(multiLine = 3) @Parameter(optionality = Optionality.OPTIONAL) String description
             ) {
         setRegistrationDate(registrationDate);
         setRegistrationNumber(registrationNumber);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTurnoverRent.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTurnoverRent.java
@@ -32,7 +32,6 @@ import org.joda.time.LocalDate;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 
@@ -71,12 +70,12 @@ public class LeaseTermForTurnoverRent extends LeaseTerm {
     private BigDecimal auditedTurnover;
 
     public LeaseTermForTurnoverRent changeParameters(
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Turnover rent rule") String newTurnoverRentRule,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Total budgeted rent") BigDecimal newTotalBudgetedRent,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Audited Turnover") BigDecimal newAuditedTurnover) {
-        setTurnoverRentRule(newTurnoverRentRule);
-        setTotalBudgetedRent(newTotalBudgetedRent);
-        setAuditedTurnover(newAuditedTurnover);
+            final @Parameter(optionality = Optionality.OPTIONAL) String turnoverRentRule,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal totalBudgetedRent,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal auditedTurnover) {
+        setTurnoverRentRule(turnoverRentRule);
+        setTotalBudgetedRent(totalBudgetedRent);
+        setAuditedTurnover(auditedTurnover);
         setStatus(LeaseTermStatus.NEW);
         doAlign();
         return this;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTypes.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTypes.java
@@ -26,12 +26,11 @@ import org.apache.isis.applib.annotation.DomainServiceLayout;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
-import org.estatio.dom.UdoDomainRepositoryAndFactory;
 import org.estatio.dom.RegexValidation;
+import org.estatio.dom.UdoDomainRepositoryAndFactory;
 
 @DomainService(repositoryFor = LeaseType.class)
 @DomainServiceLayout(
@@ -49,8 +48,8 @@ public class LeaseTypes extends UdoDomainRepositoryAndFactory<LeaseType> {
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @MemberOrder(sequence = "1")
     public LeaseType newLeaseType(
-            final @ParameterLayout(named = "Reference") @Parameter(regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String reference,
-            final @ParameterLayout(named = "Name") @Parameter(optionality = Optionality.OPTIONAL) String name) {
+            final @Parameter(regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String reference,
+            final @Parameter(optionality = Optionality.OPTIONAL) String name) {
         final LeaseType leaseType = newTransientInstance();
         leaseType.setReference(reference);
         leaseType.setName(name);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/Leases.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/Leases.java
@@ -84,14 +84,14 @@ public class Leases extends UdoDomainRepositoryAndFactory<Lease> {
     @MemberOrder(sequence = "1")
     public Lease newLease(
             // CHECKSTYLE:OFF ParameterNumber
-            final @ParameterLayout(named = "Reference") @Parameter(regexPattern = RegexValidation.Lease.REFERENCE, regexPatternReplacement = RegexValidation.Lease.REFERENCE_DESCRIPTION) String reference,
-            final @ParameterLayout(named = "Name") String name,
-            final @ParameterLayout(named = "Type") LeaseType leaseType,
-            final @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Duration", describedAs = "Duration in a text format. Example 6y5m2d") String duration,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End Date", describedAs = "Can be omitted when duration is filled in") LocalDate endDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Landlord") Party landlord,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Tenant") Party tenant,
+            final @Parameter(regexPattern = RegexValidation.Lease.REFERENCE, regexPatternReplacement = RegexValidation.Lease.REFERENCE_DESCRIPTION) String reference,
+            final String name,
+            final LeaseType leaseType,
+            final LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(describedAs = "Duration in a text format. Example 6y5m2d") String duration,
+            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(describedAs = "Can be omitted when duration is filled in") LocalDate endDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) Party landlord,
+            final @Parameter(optionality = Optionality.OPTIONAL) Party tenant,
             final ApplicationTenancy applicationTenancy
             // CHECKSTYLE:ON
     ) {
@@ -200,7 +200,7 @@ public class Leases extends UdoDomainRepositoryAndFactory<Lease> {
     @MemberOrder(sequence = "4")
     public List<Lease> findLeasesByBrand(
             final Brand brand,
-            final @ParameterLayout(named = "Include terminated") boolean includeTerminated) {
+            final boolean includeTerminated) {
         return findByBrand(brand, includeTerminated);
     }
 
@@ -208,7 +208,7 @@ public class Leases extends UdoDomainRepositoryAndFactory<Lease> {
     @MemberOrder(sequence = "5")
     public List<Lease> findLeasesActiveOnDate(
             final FixedAsset fixedAsset,
-            final @ParameterLayout(named = "Active On Date") LocalDate activeOnDate) {
+            final LocalDate activeOnDate) {
         return allMatches("findByAssetAndActiveOnDate", "asset", fixedAsset, "activeOnDate", activeOnDate);
     }
 
@@ -226,7 +226,7 @@ public class Leases extends UdoDomainRepositoryAndFactory<Lease> {
     @MemberOrder(sequence = "4")
     public String verifyLeasesUntil(
             final LeaseItemType leaseItemType,
-            final @ParameterLayout(named = "Until date") LocalDate untilDate) {
+            final LocalDate untilDate) {
         DateTime start = DateTime.now();
         List<Lease> leases = allLeases();
         for (Lease lease : leases) {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/Leases.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/Leases.java
@@ -189,9 +189,9 @@ public class Leases extends UdoDomainRepositoryAndFactory<Lease> {
     @Action(semantics = SemanticsOf.SAFE)
     @MemberOrder(sequence = "3")
     public List<Lease> findLeases(
-            final @ParameterLayout(named = "Reference or Name", describedAs = "May include wildcards '*' and '?'") String refOrName,
-            final @ParameterLayout(named = "Include terminated") boolean includeTerminated) {
-        String pattern = StringUtils.wildcardToCaseInsensitiveRegex(refOrName);
+            final @ParameterLayout(describedAs = "May include wildcards '*' and '?'") String referenceOrName,
+            final boolean includeTerminated) {
+        String pattern = StringUtils.wildcardToCaseInsensitiveRegex(referenceOrName);
         return allMatches("matchByReferenceOrName", "referenceOrName", pattern, "includeTerminated", includeTerminated, "date", clockService.now());
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/Occupancies.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/Occupancies.java
@@ -34,7 +34,6 @@ import org.apache.isis.applib.annotation.Contributed;
 import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.NatureOfService;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.SemanticsOf;
 import org.apache.isis.applib.services.clock.ClockService;
@@ -108,7 +107,7 @@ public class Occupancies extends UdoDomainRepositoryAndFactory<Occupancy> {
     @Action(semantics = SemanticsOf.SAFE)
     public List<Occupancy> findByBrand(
             final Brand brand,
-            final @ParameterLayout(named = "Include terminated") boolean includeTerminated) {
+            final boolean includeTerminated) {
         return allMatches(
                 "findByBrand",
                 "brand", brand,

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/Occupancy.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/Occupancy.java
@@ -32,7 +32,6 @@ import org.apache.isis.applib.annotation.ActionLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -171,8 +170,8 @@ public class Occupancy
     @Override
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     public Occupancy changeDates(
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "End Date") LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return getChangeDates().changeDates(startDate, endDate);
     }
 
@@ -203,7 +202,7 @@ public class Occupancy
 
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     public Occupancy terminate(
-            final @ParameterLayout(named = "End Date") LocalDate endDate) {
+            final LocalDate endDate) {
         setEndDate(endDate);
         return this;
     }
@@ -282,10 +281,10 @@ public class Occupancy
 
     @ActionLayout(describedAs = "Change unit size, sector, activity and/or brand")
     public Occupancy changeClassification(
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Unit size") UnitSize unitSize,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Sector") Sector sector,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Activity") Activity activity,
-            final @Parameter(optionality = Optionality.OPTIONAL) @ParameterLayout(named = "Brand") Brand brand) {
+            final @Parameter(optionality = Optionality.OPTIONAL) UnitSize unitSize,
+            final @Parameter(optionality = Optionality.OPTIONAL) Sector sector,
+            final @Parameter(optionality = Optionality.OPTIONAL) Activity activity,
+            final @Parameter(optionality = Optionality.OPTIONAL) Brand brand) {
         setUnitSize(unitSize);
         setSector(sector);
         setActivity(activity);
@@ -389,9 +388,9 @@ public class Occupancy
     // //////////////////////////////////////
 
     public Occupancy changeReportingOptions(
-            final @ParameterLayout(named = "Report Turnover") OccupancyReportingType reportTurnover,
-            final @ParameterLayout(named = "Report Rent") OccupancyReportingType reportRent,
-            final @ParameterLayout(named = "Report OCR") OccupancyReportingType reportOCR) {
+            final OccupancyReportingType reportTurnover,
+            final OccupancyReportingType reportRent,
+            final OccupancyReportingType reportOCR) {
         setReportTurnover(reportTurnover);
         setReportRent(reportRent);
         setReportOCR(reportOCR);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/breaks/BreakOption.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/breaks/BreakOption.java
@@ -259,7 +259,7 @@ public abstract class BreakOption
     // //////////////////////////////////////
 
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT_ARE_YOU_SURE)
-    public void remove(final @ParameterLayout(named = "Reason") String reason) {
+    public void remove(final String reason) {
         for (Event event : findEvents()) {
             events.remove(event);
         }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/breaks/BreakOption.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/breaks/BreakOption.java
@@ -39,7 +39,6 @@ import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -202,11 +201,11 @@ public abstract class BreakOption
     // //////////////////////////////////////
 
     public BreakOption change(
-            final @ParameterLayout(named = "Type") BreakType breakType,
-            final @ParameterLayout(named = "Exercise Type") BreakExerciseType breakExerciseType,
-            final @ParameterLayout(named = "Description") @Parameter(optionality = Optionality.OPTIONAL) String description) {
-        setType(breakType);
-        setExerciseType(breakExerciseType);
+            final BreakType type,
+            final BreakExerciseType exerciseType,
+            final @Parameter(optionality = Optionality.OPTIONAL) String description) {
+        setType(type);
+        setExerciseType(exerciseType);
         setDescription(description);
 
         // re-create events
@@ -236,10 +235,10 @@ public abstract class BreakOption
     }
 
     public BreakOption changeDates(
-            final @ParameterLayout(named = "Break date") LocalDate newBreakDate,
-            final @ParameterLayout(named = "Excercise date") LocalDate newExcerciseDate) {
-        setBreakDate(newBreakDate);
-        setExerciseDate(newExcerciseDate);
+            final LocalDate breakDate,
+            final LocalDate excerciseDate) {
+        setBreakDate(breakDate);
+        setExerciseDate(excerciseDate);
 
         // re-create events
         removeExistingEvents();

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/breaks/BreakOptions.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/breaks/BreakOptions.java
@@ -57,7 +57,7 @@ public class BreakOptions extends UdoDomainRepositoryAndFactory<BreakOption> {
             final @ParameterLayout(named = "Notification period", describedAs = "Notification period in a text format. Example 6y5m2d") String notificationPeriodStr,
             final BreakType breakType,
             final BreakExerciseType breakExerciseType,
-            final @ParameterLayout(named = "Description") @Parameter(optionality = Optionality.OPTIONAL) String description
+            final @Parameter(optionality = Optionality.OPTIONAL) String description
     ) {
         final BreakOption breakOption = newTransientInstance(breakType.getFactoryClass());
         breakOption.setType(breakType);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/breaks/BreakOptions.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/breaks/BreakOptions.java
@@ -53,8 +53,8 @@ public class BreakOptions extends UdoDomainRepositoryAndFactory<BreakOption> {
     @ActionLayout(contributed = Contributed.AS_ACTION)
     public Lease newBreakOption(
             final Lease lease,
-            final @ParameterLayout(named = "Break date") LocalDate breakDate,
-            final @ParameterLayout(named = "Notification period", describedAs = "Notification period in a text format. Example 6y5m2d") String notificationPeriodStr,
+            final LocalDate breakDate,
+            final @ParameterLayout(describedAs = "Notification period in a text format. Example 6y5m2d") String notificationPeriod,
             final BreakType breakType,
             final BreakExerciseType breakExerciseType,
             final @Parameter(optionality = Optionality.OPTIONAL) String description
@@ -64,8 +64,8 @@ public class BreakOptions extends UdoDomainRepositoryAndFactory<BreakOption> {
         breakOption.setLease(lease);
         breakOption.setExerciseType(breakExerciseType);
         breakOption.setBreakDate(breakDate);
-        breakOption.setNotificationPeriod(notificationPeriodStr);
-        breakOption.setExerciseDate(breakDate.minus(JodaPeriodUtils.asPeriod(notificationPeriodStr)));
+        breakOption.setNotificationPeriod(notificationPeriod);
+        breakOption.setExerciseDate(breakDate.minus(JodaPeriodUtils.asPeriod(notificationPeriod)));
         breakOption.setDescription(description);
         persist(breakOption);
         return lease;

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/invoicing/InvoiceService.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/invoicing/InvoiceService.java
@@ -7,7 +7,6 @@ import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.DomainServiceLayout;
 import org.apache.isis.applib.annotation.InvokeOn;
 import org.apache.isis.applib.annotation.MemberOrder;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
 import org.isisaddons.module.security.dom.tenancy.ApplicationTenancy;
@@ -41,17 +40,17 @@ public class InvoiceService extends UdoDomainService<InvoiceService> {
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @MemberOrder(name = "Invoices", sequence = "1")
     public Object calculateInvoicesForProperty(
-            final @ParameterLayout(named = "Property") Property property,
-            final @ParameterLayout(named = "Run Type") InvoiceRunType invoiceRunType,
-            final @ParameterLayout(named = "Selection") InvoiceCalculationSelection calculationSelection,
-            final @ParameterLayout(named = "Invoice due date") LocalDate invoiceDueDate,
-            final @ParameterLayout(named = "Start due date") LocalDate startDueDate,
-            final @ParameterLayout(named = "Next due date") LocalDate nextDueDate) {
+            final Property property,
+            final InvoiceRunType runType,
+            final InvoiceCalculationSelection selection,
+            final LocalDate invoiceDueDate,
+            final LocalDate startDueDate,
+            final LocalDate nextDueDate) {
         final String runId = invoiceCalculationService.calculateAndInvoice(
                 new InvoiceCalculationParameters(
                         property,
-                        calculationSelection.selectedTypes(),
-                        invoiceRunType,
+                        selection.selectedTypes(),
+                        runType,
                         invoiceDueDate,
                         startDueDate,
                         nextDueDate));

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/invoicing/InvoiceService.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/invoicing/InvoiceService.java
@@ -135,9 +135,9 @@ public class InvoiceService extends UdoDomainService<InvoiceService> {
             final Lease lease,
             final InvoiceRunType runType,
             final InvoiceCalculationSelection calculationSelection,
-            final @ParameterLayout(named = "Invoice due date") LocalDate invoiceDueDate,
-            final @ParameterLayout(named = "Start due date") LocalDate startDueDate,
-            final @ParameterLayout(named = "Next due date") LocalDate nextDueDate) {
+            final LocalDate invoiceDueDate,
+            final LocalDate startDueDate,
+            final LocalDate nextDueDate) {
         String runId = invoiceCalculationService.calculateAndInvoice(
                 new InvoiceCalculationParameters(
                         lease,

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/tags/Brand.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/tags/Brand.java
@@ -28,7 +28,6 @@ import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -138,13 +137,13 @@ public class Brand
     // //////////////////////////////////////
 
     public Brand change(
-            final @ParameterLayout(named = "Name") String name,
-            final @ParameterLayout(named = "Group") @Parameter(optionality = Optionality.OPTIONAL) String group,
-            final @ParameterLayout(named = "Coverage") @Parameter(optionality = Optionality.OPTIONAL) BrandCoverage brandCoverage,
-            final @ParameterLayout(named = "Country of origin") @Parameter(optionality = Optionality.OPTIONAL) Country countryOfOrigin) {
+            final String name,
+            final @Parameter(optionality = Optionality.OPTIONAL) String group,
+            final @Parameter(optionality = Optionality.OPTIONAL) BrandCoverage coverage,
+            final @Parameter(optionality = Optionality.OPTIONAL) Country countryOfOrigin) {
         setName(name);
         setGroup(group);
-        setCoverage(brandCoverage);
+        setCoverage(coverage);
         setCountryOfOrigin(countryOfOrigin);
         return this;
     }
@@ -182,11 +181,11 @@ public class Brand
 
     @Action(domainEvent = Brand.RemoveEvent.class, semantics = SemanticsOf.NON_IDEMPOTENT_ARE_YOU_SURE)
     public Object removeAndReplace(
-            final @ParameterLayout(named = "Replace with") @Parameter(optionality = Optionality.OPTIONAL) Brand replacement) {
+            final @Parameter(optionality = Optionality.OPTIONAL) Brand replaceWith) {
         getContainer().remove(this);
         getContainer().flush();
 
-        return replacement;
+        return replaceWith;
     }
 
     public String validateRemoveAndReplace(final Brand brand) {

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/tags/Brands.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/tags/Brands.java
@@ -61,10 +61,10 @@ public class Brands extends UdoDomainRepositoryAndFactory<Brand> {
 
     @MemberOrder(sequence = "1")
     public Brand newBrand(
-            final @ParameterLayout(named = "Brand name") String name,
-            final @ParameterLayout(named = "Brand coverage") @Parameter(optionality = Optionality.OPTIONAL) BrandCoverage coverage,
-            final @ParameterLayout(named = "Country of origin") @Parameter(optionality = Optionality.OPTIONAL) Country countryOfOrigin,
-            final @ParameterLayout(named = "Group") @Parameter(optionality = Optionality.OPTIONAL) String group,
+            final String name,
+            final @Parameter(optionality = Optionality.OPTIONAL) BrandCoverage coverage,
+            final @Parameter(optionality = Optionality.OPTIONAL) Country countryOfOrigin,
+            final @Parameter(optionality = Optionality.OPTIONAL) String group,
             final @ParameterLayout(named = "Global or Country") ApplicationTenancy applicationTenancy) {
         Brand brand;
         brand = newTransientInstance(Brand.class);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/tags/UnitSizes.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/tags/UnitSizes.java
@@ -26,7 +26,6 @@ import org.apache.isis.applib.annotation.Action;
 import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.DomainServiceLayout;
 import org.apache.isis.applib.annotation.MemberOrder;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.SemanticsOf;
 import org.apache.isis.applib.annotation.Where;
@@ -47,9 +46,9 @@ public class UnitSizes extends UdoDomainRepositoryAndFactory<UnitSize> {
 
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @MemberOrder(sequence = "1")
-    public UnitSize newUnitSize(final @ParameterLayout(named = "Unit size name") String name) {
+    public UnitSize newUnitSize(final String unitSizeName) {
         UnitSize unitSize = newTransientInstance(UnitSize.class);
-        unitSize.setName(name);
+        unitSize.setName(unitSizeName);
         persist(unitSize);
         return unitSize;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/Organisation.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/Organisation.java
@@ -25,7 +25,6 @@ import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.Where;
@@ -85,9 +84,9 @@ public class Organisation
 
     @Property(optionality = Optionality.OPTIONAL)
     public Organisation change(
-            final @ParameterLayout(named = "Name") String name,
-            final @ParameterLayout(named = "Vat Code") @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String vatCode,
-            final @ParameterLayout(named = "Fiscal Code") @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String fiscalCode) {
+            final String name,
+            final @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String vatCode,
+            final @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.REFERENCE, regexPatternReplacement = RegexValidation.REFERENCE_DESCRIPTION) String fiscalCode) {
         setName(name);
         setVatCode(vatCode);
         setFiscalCode(fiscalCode);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/Party.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/Party.java
@@ -34,7 +34,6 @@ import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.Where;
 
@@ -151,7 +150,7 @@ public abstract class Party
     }
 
     @Action(domainEvent = Party.RemoveEvent.class)
-    public void removeAndReplace(@ParameterLayout(named = "Replace with") @Parameter(optionality = Optionality.OPTIONAL) Party replacement) {
+    public void removeAndReplace(@Parameter(optionality = Optionality.OPTIONAL) Party replaceWith) {
         getContainer().remove(this);
         getContainer().flush();
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/Person.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/Person.java
@@ -25,7 +25,6 @@ import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.Where;
@@ -117,10 +116,10 @@ public class Person
     }
 
     public Person change(
-            final @ParameterLayout(named = "Gender") PersonGenderType gender,
-            final @ParameterLayout(named = "initials") @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.Person.INITIALS, regexPatternReplacement = RegexValidation.Person.INITIALS_DESCRIPTION) String initials,
-            final @ParameterLayout(named = "First name") String firstName,
-            final @ParameterLayout(named = "Last name") String lastName) {
+            final PersonGenderType gender,
+            final @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.Person.INITIALS, regexPatternReplacement = RegexValidation.Person.INITIALS_DESCRIPTION) String initials,
+            final String firstName,
+            final String lastName) {
         setGender(gender);
         setInitials(initials);
         setFirstName(firstName);

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/relationship/PartyRelationship.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/relationship/PartyRelationship.java
@@ -18,7 +18,6 @@ import org.apache.isis.applib.AbstractDomainObject;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.MemberOrder;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 
 import org.estatio.dom.JdoColumnLength;
@@ -108,8 +107,8 @@ public class PartyRelationship extends AbstractDomainObject implements WithInter
     }
 
     public PartyRelationship changeDates(
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @ParameterLayout(named = "End date") LocalDate endDate) {
+            final LocalDate startDate,
+            final LocalDate endDate) {
         setStartDate(startDate);
         setEndDate(endDate);
         return this;
@@ -137,7 +136,7 @@ public class PartyRelationship extends AbstractDomainObject implements WithInter
     private String description;
 
     public PartyRelationship changeDescription(
-            final @ParameterLayout(named = "Description") String description) {
+            final String description) {
         setDescription(description);
         return this;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/relationship/PartyRelationshipView.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/relationship/PartyRelationshipView.java
@@ -20,7 +20,6 @@ package org.estatio.dom.party.relationship;
 import org.joda.time.LocalDate;
 
 import org.apache.isis.applib.annotation.MemberOrder;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
 import org.apache.isis.applib.annotation.ViewModel;
@@ -108,8 +107,8 @@ public class PartyRelationshipView extends EstatioViewModel {
     private LocalDate startDate;
 
     public PartyRelationshipView changeDates(
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @ParameterLayout(named = "End date") LocalDate endDate) {
+            final LocalDate startDate,
+            final LocalDate endDate) {
         return new PartyRelationshipView(partyRelationship.changeDates(startDate, endDate), getFrom());
     }
 
@@ -139,7 +138,7 @@ public class PartyRelationshipView extends EstatioViewModel {
     private String description;
 
     public PartyRelationshipView changeDescription(
-            final @ParameterLayout(named = "Description") String description) {
+            final String description) {
         return new PartyRelationshipView(partyRelationship.changeDescription(description), getFrom());
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/party/relationship/PartyRelationships.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/party/relationship/PartyRelationships.java
@@ -14,7 +14,6 @@ import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.NatureOfService;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.RestrictTo;
 import org.apache.isis.applib.annotation.SemanticsOf;
@@ -48,13 +47,13 @@ public class PartyRelationships extends UdoDomainRepositoryAndFactory<PartyRelat
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     @MemberOrder(sequence = "1")
     public PartyRelationship newRelationship(
-            final @ParameterLayout(named = "From party") Party from,
-            final @ParameterLayout(named = "To party") Party to,
-            final @ParameterLayout(named = "Relationship type") String relationshipType,
-            final @ParameterLayout(named = "Description") @Parameter(optionality = Optionality.OPTIONAL) String description) {
-        PartyRelationship relationship = getContainer().injectServicesInto(PartyRelationshipType.createWithToTitle(from, to, relationshipType));
-        relationship.setFrom(from);
-        relationship.setTo(to);
+            final Party fromParty,
+            final Party toParty,
+            final String relationshipType,
+            final @Parameter(optionality = Optionality.OPTIONAL) String description) {
+        PartyRelationship relationship = getContainer().injectServicesInto(PartyRelationshipType.createWithToTitle(fromParty, toParty, relationshipType));
+        relationship.setFrom(fromParty);
+        relationship.setTo(toParty);
         relationship.setDescription(description);
         persistIfNotAlready(relationship);
         return relationship;
@@ -85,15 +84,15 @@ public class PartyRelationships extends UdoDomainRepositoryAndFactory<PartyRelat
     @Action(semantics = SemanticsOf.NON_IDEMPOTENT)
     public PartyRelationship newRelatedPerson(
             final Party party,
-            final @ParameterLayout(named = "Reference") @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.Person.REFERENCE, regexPatternReplacement = RegexValidation.Person.REFERENCE_DESCRIPTION) String reference,
-            final @ParameterLayout(named = "Initials") @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.Person.INITIALS, regexPatternReplacement = RegexValidation.Person.INITIALS_DESCRIPTION) String initials,
-            final @ParameterLayout(named = "First name") @Parameter(optionality = Optionality.OPTIONAL) String firstName,
-            final @ParameterLayout(named = "Last name") String lastName,
-            final @ParameterLayout(named = "Gender") PersonGenderType gender,
-            final @ParameterLayout(named = "Relationship type") String relationshipType,
-            final @ParameterLayout(named = "Description") @Parameter(optionality = Optionality.OPTIONAL) String description,
-            final @ParameterLayout(named = "Phone number") @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.CommunicationChannel.PHONENUMBER, regexPatternReplacement = RegexValidation.CommunicationChannel.PHONENUMBER_DESCRIPTION) String phoneNumber,
-            final @ParameterLayout(named = "Email address") @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.CommunicationChannel.EMAIL, regexPatternReplacement = RegexValidation.CommunicationChannel.EMAIL_DESCRIPTION) String emailAddress
+            final @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.Person.REFERENCE, regexPatternReplacement = RegexValidation.Person.REFERENCE_DESCRIPTION) String reference,
+            final @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.Person.INITIALS, regexPatternReplacement = RegexValidation.Person.INITIALS_DESCRIPTION) String initials,
+            final @Parameter(optionality = Optionality.OPTIONAL) String firstName,
+            final String lastName,
+            final PersonGenderType gender,
+            final String relationshipType,
+            final @Parameter(optionality = Optionality.OPTIONAL) String description,
+            final @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.CommunicationChannel.PHONENUMBER, regexPatternReplacement = RegexValidation.CommunicationChannel.PHONENUMBER_DESCRIPTION) String phoneNumber,
+            final @Parameter(optionality = Optionality.OPTIONAL, regexPattern = RegexValidation.CommunicationChannel.EMAIL, regexPatternReplacement = RegexValidation.CommunicationChannel.EMAIL_DESCRIPTION) String emailAddress
             ) {
 
         RandomCodeGenerator10Chars generator = new RandomCodeGenerator10Chars();

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/BusinessCase.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/BusinessCase.java
@@ -116,17 +116,12 @@ public class BusinessCase extends UdoDomainObject<BusinessCase> implements Chain
 	
 	@Action(semantics=SemanticsOf.NON_IDEMPOTENT)
 	public BusinessCase updateBusinessCase(
-			@ParameterLayout(
-					named = "Description",
-					multiLine = 5
-					)
-			final String businessCaseDescription,
-			@ParameterLayout(named = "Next review date")
-			final LocalDate reviewDate){
+			final @ParameterLayout(multiLine = 5) String description,
+			final LocalDate nextReviewDate){
 		
 		final LocalDate now = LocalDate.now();
 		
-		BusinessCase nextBusinesscase = businesscases.newBusinessCase(this.getProject(), businessCaseDescription, reviewDate, this.date, now, this.getBusinessCaseVersion() + 1);
+		BusinessCase nextBusinesscase = businesscases.newBusinessCase(this.getProject(), description, nextReviewDate, this.date, now, this.getBusinessCaseVersion() + 1);
 		this.setNext(nextBusinesscase);
 		
 		return nextBusinesscase;
@@ -140,7 +135,7 @@ public class BusinessCase extends UdoDomainObject<BusinessCase> implements Chain
 		return this.getNextReviewDate();
 	}
 	
-	public boolean hideUpdateBusinessCase(final String businessCaseDescription, final LocalDate reviewDate) {
+	public boolean hideUpdateBusinessCase(final String description, final LocalDate reviewDate) {
 		
 		if (this.getNext()==null) {
 			return false;
@@ -149,7 +144,7 @@ public class BusinessCase extends UdoDomainObject<BusinessCase> implements Chain
 		return true;
 	}
 	
-	public String validateUpdateBusinessCase(final String businessCaseDescription, final LocalDate reviewDate) {
+	public String validateUpdateBusinessCase(final String description, final LocalDate reviewDate) {
 		
 		if (this.getNext()!=null) {
 			return "This is no active version of the business case and cannot be updated";

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/BusinessCaseContributions.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/BusinessCaseContributions.java
@@ -21,17 +21,12 @@ public class BusinessCaseContributions  {
     @MemberOrder(sequence = "1")
 	public BusinessCase newBusinessCase(
 			final Project project,
-			@ParameterLayout(
-					named = "Description",
-					multiLine = 5
-					)
-			final String businessCaseDescription,
-			@ParameterLayout(named = "Next review date")
-			final LocalDate reviewDate
+			final @ParameterLayout(multiLine = 5) String description,
+			final LocalDate nextReviewDate
 			){
 		
 		final LocalDate now = LocalDate.now();
-		return businesscases.newBusinessCase(project, businessCaseDescription, reviewDate, now, null, 1);
+		return businesscases.newBusinessCase(project, description, nextReviewDate, now, null, 1);
 	}
 	
 	public boolean hideNewBusinessCase(final Project project, final String businessCaseDescription, final LocalDate reviewDate){

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/Program.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/Program.java
@@ -144,12 +144,10 @@ public class Program
     // //////////////////////////////////////
     
     public Program changeProgram(
-    		@ParameterLayout(named = "Program name")
-    		final String name,
-    		@ParameterLayout(multiLine = 5, named = "Program goal")
-    		final String programGoal){
-    
-    	this.setName(name);
+    		final String programName,
+    		final @ParameterLayout(multiLine = 5) String programGoal)
+    {
+    	this.setName(programName);
     	this.setProgramGoal(programGoal);
     	
     	return this;
@@ -162,7 +160,6 @@ public class Program
     public String default1ChangeProgram() {
     	return this.getProgramGoal();
     }
-    
     
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/ProgramRole.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/ProgramRole.java
@@ -37,7 +37,6 @@ import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -169,8 +168,8 @@ public class ProgramRole
     @Action(semantics=SemanticsOf.IDEMPOTENT)
     @Override
     public ProgramRole changeDates(
-            final @ParameterLayout(named = "Start Date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
         helper.changeDates(startDate, endDate);
         return this;
     }
@@ -294,8 +293,8 @@ public class ProgramRole
 
     public ProgramRole succeededBy(
             final Party party,
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
+            final LocalDate startDate,
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
         return helper.succeededBy(startDate, endDate, new SiblingFactory(this, party));
     }
 
@@ -324,8 +323,8 @@ public class ProgramRole
 
     public ProgramRole precededBy(
             final Party party,
-            final @ParameterLayout(named = "Start date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End date") LocalDate endDate) {
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
+            final LocalDate endDate) {
 
         return helper.precededBy(startDate, endDate, new SiblingFactory(this, party));
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/ProgramRolesContributions.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/ProgramRolesContributions.java
@@ -33,7 +33,6 @@ import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.NatureOfService;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.RenderType;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
@@ -54,10 +53,10 @@ public class ProgramRolesContributions  {
     @ActionLayout(contributed=Contributed.AS_ACTION)
     public Program newProgramRole(
     		final Program program,
-            final @ParameterLayout(named = "Type") ProgramRoleType type,
+            final ProgramRoleType type,
             final Party party,
-            final @ParameterLayout(named = "Start date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
     	programRoles.createRole(program, type, party, startDate, endDate);
         return program;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/ProjectRole.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/ProjectRole.java
@@ -169,8 +169,8 @@ public class ProjectRole
     @Action(semantics=SemanticsOf.IDEMPOTENT)
     @Override
     public ProjectRole changeDates(
-            final @ParameterLayout(named = "Start Date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
         helper.changeDates(startDate, endDate);
         return this;
     }
@@ -291,8 +291,8 @@ public class ProjectRole
 
     public ProjectRole succeededBy(
             final Party party,
-            final @ParameterLayout(named = "Start date") LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
+            final LocalDate startDate,
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
         return helper.succeededBy(startDate, endDate, new SiblingFactory(this, party));
     }
 
@@ -321,8 +321,8 @@ public class ProjectRole
 
     public ProjectRole precededBy(
             final Party party,
-            final @ParameterLayout(named = "Start date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End date") LocalDate endDate) {
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
+            final LocalDate endDate) {
 
         return helper.precededBy(startDate, endDate, new SiblingFactory(this, party));
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/project/ProjectRolesContributions.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/project/ProjectRolesContributions.java
@@ -33,7 +33,6 @@ import org.apache.isis.applib.annotation.DomainService;
 import org.apache.isis.applib.annotation.NatureOfService;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.RenderType;
 import org.apache.isis.applib.annotation.SemanticsOf;
 
@@ -55,10 +54,10 @@ public class ProjectRolesContributions {
     
     public Project newProjectRole(
     		final Project project,
-            final @ParameterLayout(named = "Type") ProjectRoleType type,
+            final ProjectRoleType type,
             final Party party,
-            final @ParameterLayout(named = "Start date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End date") @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {    	
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality=Optionality.OPTIONAL) LocalDate endDate) {
         projectRoles.createRole(project, type, party, startDate, endDate);
         return project;
     }

--- a/estatioapp/dom/src/main/java/org/estatio/dom/tax/Tax.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/tax/Tax.java
@@ -32,7 +32,6 @@ import org.apache.isis.applib.annotation.CollectionLayout;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -150,8 +149,8 @@ public class Tax
     // //////////////////////////////////////
 
     public TaxRate newRate(
-            final @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @ParameterLayout(named = "Percentage") BigDecimal percentage) {
+            final LocalDate startDate,
+            final BigDecimal percentage) {
         return taxRates.newRate(this, startDate, percentage);
     }
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/tax/TaxRate.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/tax/TaxRate.java
@@ -31,7 +31,6 @@ import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.Editing;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
-import org.apache.isis.applib.annotation.ParameterLayout;
 import org.apache.isis.applib.annotation.Programmatic;
 import org.apache.isis.applib.annotation.Property;
 import org.apache.isis.applib.annotation.PropertyLayout;
@@ -125,8 +124,8 @@ public class TaxRate
     @Override
     @Action(semantics = SemanticsOf.IDEMPOTENT)
     public TaxRate changeDates(
-            final @ParameterLayout(named = "Start Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
-            final @ParameterLayout(named = "End Date") @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate startDate,
+            final @Parameter(optionality = Optionality.OPTIONAL) LocalDate endDate) {
         return getChangeDates().changeDates(startDate, endDate);
     }
 
@@ -222,8 +221,8 @@ public class TaxRate
     // //////////////////////////////////////
 
     public TaxRate newRate(
-            final @ParameterLayout(named = "Start Date") LocalDate startDate,
-            final @ParameterLayout(named = "Percentage") BigDecimal percentage) {
+            final LocalDate startDate,
+            final BigDecimal percentage) {
         TaxRate rate = this.getTax().newRate(startDate, percentage);
         setNext(rate);
         rate.setPrevious(this);
@@ -231,9 +230,9 @@ public class TaxRate
     }
 
     public TaxRate change(
-            final @ParameterLayout(named = "Tax") Tax tax,
-            final @ParameterLayout(named = "Percentage") @Parameter(optionality = Optionality.OPTIONAL) BigDecimal percentage,
-            final @ParameterLayout(named = "External Reference") @Parameter(optionality = Optionality.OPTIONAL) String externalReference) {
+            final Tax tax,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal percentage,
+            final @Parameter(optionality = Optionality.OPTIONAL) String externalReference) {
 
         setTax(tax);
         setPercentage(percentage);


### PR DESCRIPTION
2 commits:
- First commit is the removal of superfluous (named = ...) in @parameterlayout annotation
e.g. @ParameterLayout(named = "name") String name
- Second commit is the removal of above mentioned (named = ...) but with renaming of variable name to maintain the same displayed variable name.