### PR TITLE
Est 653 unittype not affected by change action

### DIFF
--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAsset.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/FixedAsset.java
@@ -37,7 +37,6 @@ import org.apache.isis.applib.annotation.CollectionLayout;
 import org.apache.isis.applib.annotation.DomainObject;
 import org.apache.isis.applib.annotation.DomainObjectLayout;
 import org.apache.isis.applib.annotation.Editing;
-import org.apache.isis.applib.annotation.MemberOrder;
 import org.apache.isis.applib.annotation.Optionality;
 import org.apache.isis.applib.annotation.Parameter;
 import org.apache.isis.applib.annotation.Programmatic;
@@ -145,21 +144,10 @@ public abstract class FixedAsset<X extends FixedAsset<X>>
 
     // //////////////////////////////////////
 
-
     @javax.jdo.annotations.Column(allowsNull = "true", length = JdoColumnLength.REFERENCE)
     @Property(optionality = Optionality.OPTIONAL)
     @Getter @Setter
     private String externalReference;
-
-    @MemberOrder(name = "externalReference", sequence = "1")
-    public FixedAsset changeExternalReference(final String externalReference) {
-        setExternalReference(externalReference);
-        return this;
-    }
-
-    public String default0ChangeExternalReference(final String externalReference) {
-        return getExternalReference();
-    }
 
     // //////////////////////////////////////
 

--- a/estatioapp/dom/src/main/java/org/estatio/dom/asset/Unit.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/asset/Unit.java
@@ -230,6 +230,7 @@ public class Unit
             final UnitType type,
             final @Parameter(optionality = Optionality.OPTIONAL) String externalReference) {
         setName(name);
+        setType(type);
         setExternalReference(externalReference);
         return this;
     }

--- a/estatioapp/dom/src/test/java/org/estatio/dom/asset/UnitMenuTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/asset/UnitMenuTest.java
@@ -23,6 +23,7 @@ import org.jmock.auto.Mock;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
 import org.apache.isis.applib.DomainObjectContainer;
 import org.apache.isis.core.unittestsupport.jmocking.JUnitRuleMockery2;
 import org.apache.isis.core.unittestsupport.jmocking.JUnitRuleMockery2.Mode;
@@ -64,9 +65,31 @@ public class UnitMenuTest {
         });
 
         final Unit newUnit = unitMenu.newUnit(null, "REF-1", "Name-1", UnitType.EXTERNAL);
+
         assertThat(newUnit.getReference(), is("REF-1"));
         assertThat(newUnit.getName(), is("Name-1"));
         assertThat(newUnit.getType(), is(UnitType.EXTERNAL));
     }
+
+    @Test
+    public void changeUnit() {
+        final Unit unit = new Unit();
+        context.checking(new Expectations() {
+            {
+                oneOf(mockContainer).newTransientInstance(Unit.class);
+                will(returnValue(unit));
+
+                oneOf(mockContainer).persist(unit);
+            }
+        });
+
+        Unit changeUnit = unitMenu.newUnit(null, "REF-1", "Name-1", UnitType.EXTERNAL);
+        changeUnit.changeAsset("Name-2", UnitType.BOUTIQUE, "ExternalRef");
+
+        assertThat(changeUnit.getName(), is("Name-2"));
+        assertThat(changeUnit.getType(), is(UnitType.BOUTIQUE));
+        assertThat(changeUnit.getExternalReference(), is("ExternalRef"));
+    }
+
 
 }


### PR DESCRIPTION
Made test and edited the changeAsset in class Unit. Change asset didn't update the unittype since the entered (parameter) value wasn't set. Also removed obsolete changeExternalReference from fixedAsset since this already was editable through changeAsset in class unit. Couldnt find any other usages for changeExternalReference. Do you agree with that?