### PR TITLE
EST-694: turnoverRentRule now only allows numeric inputs. There alrea…

### DIFF
--- a/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTurnoverRent.java
+++ b/estatioapp/dom/src/main/java/org/estatio/dom/lease/LeaseTermForTurnoverRent.java
@@ -24,8 +24,6 @@ import java.util.List;
 
 import javax.jdo.annotations.InheritanceStrategy;
 
-import com.google.common.base.Strings;
-
 import org.apache.commons.lang3.ObjectUtils;
 import org.joda.time.LocalDate;
 
@@ -53,11 +51,9 @@ public class LeaseTermForTurnoverRent extends LeaseTerm {
     private String turnoverRentRule;
 
     public String validateTurnoverRentRule(final String turnoverRentrule) {
-        if (Strings.isNullOrEmpty(turnoverRentrule)) {
-            TurnoverRentRuleHelper helper = new TurnoverRentRuleHelper(turnoverRentrule);
-            if (!helper.isValid()) {
-                return "'" + turnoverRentrule + "' is not a valid rule";
-            }
+        TurnoverRentRuleHelper helper = new TurnoverRentRuleHelper(turnoverRentrule);
+        if (!helper.isValid()) {
+            return "'" + turnoverRentrule + "' is not a valid rule";
         }
         return null;
     }
@@ -91,6 +87,13 @@ public class LeaseTermForTurnoverRent extends LeaseTerm {
 
     public BigDecimal default2ChangeParameters() {
         return getAuditedTurnover();
+    }
+
+    public String validateChangeParameters(
+            final @Parameter(optionality = Optionality.OPTIONAL) String turnoverRentRule,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal totalBudgetedRent,
+            final @Parameter(optionality = Optionality.OPTIONAL) BigDecimal auditedTurnover) {
+        return validateTurnoverRentRule(turnoverRentRule);
     }
 
     // //////////////////////////////////////

--- a/estatioapp/dom/src/test/java/org/estatio/dom/lease/LeaseTermForTurnoverRentTest.java
+++ b/estatioapp/dom/src/test/java/org/estatio/dom/lease/LeaseTermForTurnoverRentTest.java
@@ -18,13 +18,9 @@
  */
 package org.estatio.dom.lease;
 
-import org.apache.isis.core.unittestsupport.jmocking.JUnitRuleMockery2;
-import org.estatio.dom.AbstractBeanPropertiesTest;
-import org.estatio.dom.PojoTester.FixtureDatumFactory;
-import org.estatio.dom.invoice.InvoicingInterval;
-import org.estatio.dom.lease.invoicing.InvoiceCalculationService;
-import org.estatio.dom.valuetypes.LocalDateInterval;
-import org.isisaddons.module.security.dom.tenancy.ApplicationTenancy;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+
 import org.jmock.Expectations;
 import org.jmock.auto.Mock;
 import org.joda.time.LocalDate;
@@ -33,8 +29,15 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
+import org.apache.isis.core.unittestsupport.jmocking.JUnitRuleMockery2;
+
+import org.isisaddons.module.security.dom.tenancy.ApplicationTenancy;
+
+import org.estatio.dom.AbstractBeanPropertiesTest;
+import org.estatio.dom.PojoTester.FixtureDatumFactory;
+import org.estatio.dom.invoice.InvoicingInterval;
+import org.estatio.dom.lease.invoicing.InvoiceCalculationService;
+import org.estatio.dom.valuetypes.LocalDateInterval;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -177,12 +180,36 @@ public class LeaseTermForTurnoverRentTest {
         @Before
         public void setup() {
             super.setup();
-            term.setTurnoverRentRule("7.00");
         }
 
         @Test
-        public void whenReturnsNull() {
+        public void correct_float() {
             Assert.assertNull(term.validateTurnoverRentRule("7.00"));
+        }
+
+        @Test
+        public void correct_int() {
+            Assert.assertNull(term.validateTurnoverRentRule("7"));
+        }
+
+        @Test
+        public void incorrect_empty()  {
+            Assert.assertNotNull(term.validateTurnoverRentRule(""));
+        }
+
+        @Test
+        public void incorrect_null()  {
+            Assert.assertNotNull(term.validateTurnoverRentRule(null));
+        }
+
+        @Test
+        public void incorrect_comma()  {
+            Assert.assertNotNull(term.validateTurnoverRentRule("7,0"));
+        }
+
+        @Test
+        public void incorrect_NaN()  {
+            Assert.assertNotNull(term.validateTurnoverRentRule("Se7en"));
         }
     }
 


### PR DESCRIPTION
…dy was a validate function, but it wasn't being used and there was an error in it. This fixes that. Also includes unit tests for a number of test cases