### PR TITLE
Est 713 - simplifying EstatioAppManifest and subclasses

### DIFF
--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -154,9 +154,6 @@ public class EstatioAppManifest implements AppManifest {
         // withHsqldbLogging(props);
         // withSqlServerUrl(props);
 
-        withFacetFactory(props, "org.isisaddons.module.security.facets.TenantedAuthorizationFacetFactory");
-        withFacetFactory(props, "org.isisaddons.metamodel.paraname8.NamedFacetOnParameterParaname8Factory");
-
         props.put("isis.persistor.datanucleus.impl.datanucleus.deletionPolicy", "DataNucleus");
 
         return props;
@@ -209,14 +206,6 @@ public class EstatioAppManifest implements AppManifest {
         return props;
     }
 
-
-    private static Map<String, String> withFacetFactory(Map<String, String> props, String facetFactory) {
-        String facetFactoryList = props.get("isis.reflector.facets.include");
-        facetFactoryList = (facetFactoryList != null ? facetFactoryList + "," : "") + facetFactory;
-        props.put("isis.reflector.facets.include", facetFactoryList);
-
-        return props;
-    }
 
 
     protected static Map<String, String> withInstallFixtures(Map<String, String> props) {

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -34,16 +34,23 @@ public class EstatioAppManifest implements AppManifest {
 
     private final List<Class<? extends FixtureScript>> fixtureScripts;
     private final String authMechanism;
+    private final List<Class<?>> additionalModules;
 
     public EstatioAppManifest() {
-        this(Collections.emptyList(), null);
+        this(
+                Collections.emptyList(),
+                null,
+                Collections.emptyList()
+        );
     }
 
     public EstatioAppManifest(
             final List<Class<? extends FixtureScript>> fixtureScripts,
-            final String authMechanism) {
+            final String authMechanism,
+            final List<Class<?>> additionalModules) {
         this.fixtureScripts = elseNullIfEmpty(fixtureScripts);
         this.authMechanism = authMechanism;
+        this.additionalModules = elseNullIfEmpty(additionalModules);
     }
 
     static <T> List<T> elseNullIfEmpty(final List<T> list) {
@@ -62,7 +69,11 @@ public class EstatioAppManifest implements AppManifest {
         return modules;
     }
 
-    protected void appendAdditionalModules(final List<Class<?>> modules) {
+    private void appendAdditionalModules(final List<Class<?>> modules) {
+        if(additionalModules == null) {
+            return;
+        }
+        modules.addAll(additionalModules);
     }
 
     protected List<Class<?>> appendDomModulesAndSecurityAndCommandAddon(List<Class<?>> modules) {
@@ -95,7 +106,7 @@ public class EstatioAppManifest implements AppManifest {
         return modules;
     }
 
-    protected List<Class<?>> appendAddonModules(List<Class<?>> modules) {
+    private List<Class<?>> appendAddonModules(List<Class<?>> modules) {
         modules.addAll(
                 Arrays.asList(
                         org.isisaddons.module.excel.ExcelModule.class,
@@ -110,7 +121,7 @@ public class EstatioAppManifest implements AppManifest {
         return modules;
     }
 
-    protected List<Class<?>> appendAddonWicketComponents(List<Class<?>> modules) {
+    private List<Class<?>> appendAddonWicketComponents(List<Class<?>> modules) {
         modules.addAll(
                 Arrays.asList(
                         // apart from gmap3-service, the other modules here contain no services or entities

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -154,7 +154,6 @@ public class EstatioAppManifest implements AppManifest {
         // withHsqldbLogging(props);
         // withSqlServerUrl(props);
 
-        props.put("isis.persistor.datanucleus.impl.datanucleus.deletionPolicy", "DataNucleus");
 
         return props;
     }

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -123,29 +123,16 @@ public class EstatioAppManifest implements AppManifest {
     }
 
     @Override
-    public List<Class<?>> getAdditionalServices() {
+    public final List<Class<?>> getAdditionalServices() {
         List<Class<?>> additionalServices = Lists.newArrayList();
-        appendEstatioCalendarService(additionalServices);
-        appendOptionalServicesForSecurityModule(additionalServices);
+        additionalServices.addAll(
+            Arrays.asList(
+                CalendarService.class, // TODO: instead, should have a module for this
+                org.isisaddons.module.security.dom.password.PasswordEncryptionServiceUsingJBcrypt.class,
+                org.isisaddons.module.security.dom.permission.PermissionsEvaluationServiceAllowBeatsVeto.class
+                )
+        );
         return additionalServices;
-    }
-
-    protected void appendEstatioCalendarService(final List<Class<?>> additionalServices) {
-        // TODO: need to create a module for this (the Estatio ClockService... else maybe use Isis')
-        additionalServices.addAll(
-                Arrays.asList(
-                        CalendarService.class
-                )
-        );
-    }
-
-    protected void appendOptionalServicesForSecurityModule(final List<Class<?>> additionalServices) {
-        additionalServices.addAll(
-                Arrays.asList(
-                        org.isisaddons.module.security.dom.password.PasswordEncryptionServiceUsingJBcrypt.class,
-                        org.isisaddons.module.security.dom.permission.PermissionsEvaluationServiceAllowBeatsVeto.class
-                )
-        );
     }
 
     @Override

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -149,8 +149,6 @@ public class EstatioAppManifest implements AppManifest {
 
         loadPropsInto(props, "isis-non-changing.properties");
 
-        withEstatioSchemaOverrides(props);
-
         // uncomment to use log4jdbc instead
         // withLog4jdbc(props);
 
@@ -187,21 +185,6 @@ public class EstatioAppManifest implements AppManifest {
         }
     }
 
-
-    /**
-     * We need to use overrides where we have a dependency on a module whose entities is defined to reside
-     * its own schema (eg incode modules), but where we have a PK/FK relationship to its entities.
-     * In these cases, because DN (seems to) require both are in the same schema, we force the module's entity to be
-     * mapped to a table in Estatio's own schema, ie 'dbo'.
-     *
-     * We also use overrides for certain column/property mappings, eg to reduce size of the bookmark columns where
-     * these have an index on them (limited to 900 bytes).
-     */
-    private static Map<String, String> withEstatioSchemaOverrides(Map<String, String> props) {
-        // to pick up Xxx-sqlserver.orm overrides
-        props.put("isis.persistor.datanucleus.impl.datanucleus.Mapping", "sqlserver");
-        return props;
-    }
 
     private static Map<String, String> withLog4jdbc(Map<String, String> props) {
         props.put("isis.persistor.datanucleus.impl.javax.jdo.option.ConnectionDriverName",

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -58,7 +58,11 @@ public class EstatioAppManifest implements AppManifest {
         appendDomModulesAndSecurityAndCommandAddon(modules);
         appendAddonModules(modules);
         appendAddonWicketComponents(modules);
+        appendAdditionalModules(modules);
         return modules;
+    }
+
+    protected void appendAdditionalModules(final List<Class<?>> modules) {
     }
 
     protected List<Class<?>> appendDomModulesAndSecurityAndCommandAddon(List<Class<?>> modules) {

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -148,13 +148,6 @@ public class EstatioAppManifest implements AppManifest {
 
         loadPropsInto(props, "isis-non-changing.properties");
 
-        // uncomment to use log4jdbc instead
-        // withLog4jdbc(props);
-
-        // withHsqldbLogging(props);
-        // withSqlServerUrl(props);
-
-
         return props;
     }
 
@@ -176,35 +169,6 @@ public class EstatioAppManifest implements AppManifest {
                     String.format("Failed to load '%s' file ", propertiesFile), e);
         }
     }
-
-
-    private static Map<String, String> withLog4jdbc(Map<String, String> props) {
-        props.put("isis.persistor.datanucleus.impl.javax.jdo.option.ConnectionDriverName",
-                "net.sf.log4jdbc.DriverSpy");
-
-        return props;
-    }
-
-    private static Map<String, String> withHsqldbLogging(Map<String, String> props) {
-        props.put("isis.persistor.datanucleus.impl.javax.jdo.option.ConnectionURL",
-                "jdbc:hsqldb:mem:test;sqllog=3");
-
-        return props;
-    }
-
-    private static Map<String, String> withSqlServerUrl(Map<String, String> props) {
-        props.put("isis.persistor.datanucleus.impl.javax.jdo.option.ConnectionURL",
-                "jdbc:sqlserver://localhost:1433;instance=.;databaseName=estatio");
-        props.put("isis.persistor.datanucleus.impl.javax.jdo.option.ConnectionDriverName",
-                "com.microsoft.sqlserver.jdbc.SQLServerDriver");
-        props.put("isis.persistor.datanucleus.impl.javax.jdo.option.ConnectionUserName",
-                "estatio");
-        props.put("isis.persistor.datanucleus.impl.javax.jdo.option.ConnectionPassword",
-                "estatio");
-
-        return props;
-    }
-
 
 
     protected static Map<String, String> withInstallFixtures(Map<String, String> props) {

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
@@ -155,8 +154,6 @@ public class EstatioAppManifest implements AppManifest {
         // withHsqldbLogging(props);
         // withSqlServerUrl(props);
 
-        withCssClassPatterns(props);
-
         withFacetFactory(props, "org.isisaddons.module.security.facets.TenantedAuthorizationFacetFactory");
         withFacetFactory(props, "org.isisaddons.metamodel.paraname8.NamedFacetOnParameterParaname8Factory");
 
@@ -212,20 +209,6 @@ public class EstatioAppManifest implements AppManifest {
         return props;
     }
 
-    private static Map<String, String> withCssClassPatterns(Map<String, String> props) {
-        props.put("isis.reflector.facet.cssClass.patterns",
-                Joiner.on(',').join(
-                        "update.*:btn-default",
-                        "change.*:btn-default",
-                        "maintain.*:btn-default",
-                        "delete.*:btn-warning",
-                        "remove.*:btn-warning"
-                        /*,
-                        ".*:btn-primary" // this messes up the drop-downs
-                        */));
-
-        return props;
-    }
 
     private static Map<String, String> withFacetFactory(Map<String, String> props, String facetFactory) {
         String facetFactoryList = props.get("isis.reflector.facets.include");

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -3,6 +3,7 @@ package org.estatio.app;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -30,6 +31,22 @@ import org.estatio.fixturescripts.EstatioFixtureScriptsModule;
 import org.estatio.numerator.dom.NumeratorDomModule;
 
 public class EstatioAppManifest implements AppManifest {
+
+    private final List<Class<? extends FixtureScript>> fixtureScripts;
+
+    public EstatioAppManifest() {
+        this(Collections.emptyList());
+    }
+
+    public EstatioAppManifest(final List<Class<? extends FixtureScript>> fixtureScripts) {
+        this.fixtureScripts = elseNullIfEmpty(fixtureScripts);
+    }
+
+    static <T> List<T> elseNullIfEmpty(final List<T> list) {
+        return list != null && list.isEmpty()
+                ? null
+                : list;
+    }
 
     @Override
     public List<Class<?>> getModules() {
@@ -139,7 +156,7 @@ public class EstatioAppManifest implements AppManifest {
 
     @Override
     public List<Class<? extends FixtureScript>> getFixtures() {
-        return null;
+        return fixtureScripts;
     }
 
     @Override
@@ -147,6 +164,10 @@ public class EstatioAppManifest implements AppManifest {
         final Map<String, String> props = Maps.newHashMap();
 
         loadPropsInto(props, "isis-non-changing.properties");
+
+        if(fixtureScripts == null) {
+            withInstallFixtures(props);
+        }
 
         return props;
     }
@@ -171,7 +192,7 @@ public class EstatioAppManifest implements AppManifest {
     }
 
 
-    protected static Map<String, String> withInstallFixtures(Map<String, String> props) {
+    private static Map<String, String> withInstallFixtures(Map<String, String> props) {
         props.put("isis.persistor.datanucleus.install-fixtures", "true");
         return props;
     }

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -171,7 +171,7 @@ public class EstatioAppManifest implements AppManifest {
 
         loadPropsInto(props, "isis-non-changing.properties");
 
-        if(fixtureScripts == null) {
+        if(fixtureScripts != null) {
             withInstallFixtures(props);
         }
 

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -155,7 +155,6 @@ public class EstatioAppManifest implements AppManifest {
         // withHsqldbLogging(props);
         // withSqlServerUrl(props);
 
-        withCssClassFaPatterns(props);
         withCssClassPatterns(props);
 
         withFacetFactory(props, "org.isisaddons.module.security.facets.TenantedAuthorizationFacetFactory");
@@ -210,49 +209,6 @@ public class EstatioAppManifest implements AppManifest {
         props.put("isis.persistor.datanucleus.impl.javax.jdo.option.ConnectionPassword",
                 "estatio");
 
-        return props;
-    }
-
-    private static Map<String, String> withCssClassFaPatterns(Map<String, String> props) {
-        props.put("isis.reflector.facet.cssClassFa.patterns",
-                Joiner.on(',').join(
-                        "new.*:fa-plus",
-                        "add.*:fa-plus-square",
-                        "create.*:fa-plus",
-                        "update.*:fa-edit",
-                        "change.*:fa-edit",
-                        "maintain.*:fa-edit",
-                        "remove.*:fa-minus-square",
-                        "copy.*:fa-copy",
-                        "move.*:fa-arrow-right",
-                        "first.*:fa-star",
-                        "find.*:fa-search",
-                        "lookup.*:fa-search",
-                        "search.*:fa-search",
-                        "clear.*:fa-remove",
-                        "previous.*:fa-step-backward",
-                        "next.*:fa-step-forward",
-                        "list.*:fa-list",
-                        "all.*:fa-list",
-                        "download.*:fa-download",
-                        "upload.*:fa-upload",
-                        "export.*:fa-exchange",
-                        "import.*:fa-exchange",
-                        "execute.*:fa-bolt",
-                        "run.*:fa-bolt",
-                        "calculate.*:fa-calculator",
-                        "verify.*:fa-check-circle",
-                        "refresh.*:fa-refresh",
-                        "install.*:fa-wrench",
-                        "stop.*:fa-stop",
-                        "terminate.*:fa-stop",
-                        "pause.*:fa-pause",
-                        "suspend.*:fa-pause",
-                        "resume.*:fa-play",
-                        "renew.*:fa-repeat",
-                        "assign.*:fa-hand-o-right",
-                        "approve.*:fa-thumbs-o-up",
-                        "decline.*:fa-thumbs-o-down"));
         return props;
     }
 

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -33,13 +33,17 @@ import org.estatio.numerator.dom.NumeratorDomModule;
 public class EstatioAppManifest implements AppManifest {
 
     private final List<Class<? extends FixtureScript>> fixtureScripts;
+    private final String authMechanism;
 
     public EstatioAppManifest() {
-        this(Collections.emptyList());
+        this(Collections.emptyList(), null);
     }
 
-    public EstatioAppManifest(final List<Class<? extends FixtureScript>> fixtureScripts) {
+    public EstatioAppManifest(
+            final List<Class<? extends FixtureScript>> fixtureScripts,
+            final String authMechanism) {
         this.fixtureScripts = elseNullIfEmpty(fixtureScripts);
+        this.authMechanism = authMechanism;
     }
 
     static <T> List<T> elseNullIfEmpty(final List<T> list) {
@@ -145,13 +149,13 @@ public class EstatioAppManifest implements AppManifest {
     }
 
     @Override
-    public String getAuthenticationMechanism() {
-        return null;
+    public final String getAuthenticationMechanism() {
+        return authMechanism;
     }
 
     @Override
-    public String getAuthorizationMechanism() {
-        return null;
+    public final String getAuthorizationMechanism() {
+        return authMechanism;
     }
 
     @Override

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifest.java
@@ -149,8 +149,6 @@ public class EstatioAppManifest implements AppManifest {
 
         loadPropsInto(props, "isis-non-changing.properties");
 
-        withStandardProps(props);
-
         withEstatioSchemaOverrides(props);
 
         // uncomment to use log4jdbc instead
@@ -189,16 +187,6 @@ public class EstatioAppManifest implements AppManifest {
         }
     }
 
-    private static Map<String, String> withStandardProps(Map<String, String> props) {
-        // Fundamental principle is that we don't allow editing data.
-        props.put("isis.objects.editing","false");
-        props.put("isis.services.eventbus.implementation", "guava");
-        props.put("isis.services.audit.objects", "all");
-        props.put("isis.services.eventbus.allowLateRegistration", "true");
-        props.put("isis.services.injector.injectPrefix", "true");
-
-        return props;
-    }
 
     /**
      * We need to use overrides where we have a dependency on a module whose entities is defined to reside

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixture.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixture.java
@@ -1,6 +1,7 @@
 package org.estatio.app;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.estatio.fixturescripts.EstatioDemoFixture;
 
@@ -9,7 +10,8 @@ public class EstatioAppManifestWithDemoFixture extends EstatioAppManifest {
     public EstatioAppManifestWithDemoFixture() {
         super(
                 Arrays.asList(EstatioDemoFixture.class),
-                null
+                null,
+                Collections.emptyList()
         );
     }
 

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixture.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixture.java
@@ -7,7 +7,10 @@ import org.estatio.fixturescripts.EstatioDemoFixture;
 public class EstatioAppManifestWithDemoFixture extends EstatioAppManifest {
 
     public EstatioAppManifestWithDemoFixture() {
-        super(Arrays.asList(EstatioDemoFixture.class));
+        super(
+                Arrays.asList(EstatioDemoFixture.class),
+                null
+        );
     }
 
 }

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixture.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixture.java
@@ -1,26 +1,13 @@
 package org.estatio.app;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.isis.applib.fixturescripts.FixtureScript;
 
 import org.estatio.fixturescripts.EstatioDemoFixture;
 
 public class EstatioAppManifestWithDemoFixture extends EstatioAppManifest {
 
-    @Override public List<Class<? extends FixtureScript>> getFixtures() {
-        return Arrays.asList(
-                EstatioDemoFixture.class
-        );
-    }
-
-    @Override
-    public Map<String, String> getConfigurationProperties() {
-        final Map<String, String> props = super.getConfigurationProperties();
-        withInstallFixtures(props);
-        return props;
+    public EstatioAppManifestWithDemoFixture() {
+        super(Arrays.asList(EstatioDemoFixture.class));
     }
 
 }

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixtureAndDummyReportServer.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixtureAndDummyReportServer.java
@@ -1,6 +1,7 @@
 package org.estatio.app;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.estatio.fixturescripts.EstatioDemoFixtureWithDummyReportServer;
 
@@ -9,7 +10,8 @@ public class EstatioAppManifestWithDemoFixtureAndDummyReportServer extends Estat
     public EstatioAppManifestWithDemoFixtureAndDummyReportServer() {
         super(
                 Arrays.asList(EstatioDemoFixtureWithDummyReportServer.class),
-                null
+                null,
+                Collections.emptyList()
         );
     }
 

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixtureAndDummyReportServer.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixtureAndDummyReportServer.java
@@ -7,7 +7,10 @@ import org.estatio.fixturescripts.EstatioDemoFixtureWithDummyReportServer;
 public class EstatioAppManifestWithDemoFixtureAndDummyReportServer extends EstatioAppManifest {
 
     public EstatioAppManifestWithDemoFixtureAndDummyReportServer() {
-        super(Arrays.asList(EstatioDemoFixtureWithDummyReportServer.class));
+        super(
+                Arrays.asList(EstatioDemoFixtureWithDummyReportServer.class),
+                null
+        );
     }
 
 }

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixtureAndDummyReportServer.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithDemoFixtureAndDummyReportServer.java
@@ -1,25 +1,13 @@
 package org.estatio.app;
 
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.isis.applib.fixturescripts.FixtureScript;
 
 import org.estatio.fixturescripts.EstatioDemoFixtureWithDummyReportServer;
 
 public class EstatioAppManifestWithDemoFixtureAndDummyReportServer extends EstatioAppManifest {
 
-    @Override public List<Class<? extends FixtureScript>> getFixtures() {
-        return Arrays.asList(
-                EstatioDemoFixtureWithDummyReportServer.class
-        );
-    }
-
-    @Override
-    public Map<String, String> getConfigurationProperties() {
-        final Map<String, String> props = super.getConfigurationProperties();
-        return withInstallFixtures(props);
+    public EstatioAppManifestWithDemoFixtureAndDummyReportServer() {
+        super(Arrays.asList(EstatioDemoFixtureWithDummyReportServer.class));
     }
 
 }

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithoutAddonsBypassSecurity.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithoutAddonsBypassSecurity.java
@@ -1,10 +1,18 @@
 package org.estatio.app;
 
+import java.util.Collections;
 import java.util.List;
 
 import com.google.common.collect.Lists;
 
 public class EstatioAppManifestWithoutAddonsBypassSecurity extends EstatioAppManifest {
+
+    public EstatioAppManifestWithoutAddonsBypassSecurity() {
+        super(
+                Collections.emptyList(),
+                "bypass"
+        );
+    }
 
     @Override
     public List<Class<?>> getModules() {
@@ -13,11 +21,4 @@ public class EstatioAppManifestWithoutAddonsBypassSecurity extends EstatioAppMan
         return modules;
     }
 
-    @Override public String getAuthenticationMechanism() {
-        return "bypass";
-    }
-
-    @Override public String getAuthorizationMechanism() {
-        return "bypass";
-    }
 }

--- a/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithoutAddonsBypassSecurity.java
+++ b/estatioapp/app/src/main/java/org/estatio/app/EstatioAppManifestWithoutAddonsBypassSecurity.java
@@ -10,7 +10,8 @@ public class EstatioAppManifestWithoutAddonsBypassSecurity extends EstatioAppMan
     public EstatioAppManifestWithoutAddonsBypassSecurity() {
         super(
                 Collections.emptyList(),
-                "bypass"
+                "bypass",
+                Collections.emptyList()
         );
     }
 

--- a/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
+++ b/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
@@ -390,3 +390,13 @@ isis.reflector.facet.cssClassFa.patterns=\
         assign.*:fa-hand-o-right,\
         approve.*:fa-thumbs-o-up,\
         decline.*:fa-thumbs-o-down
+
+
+isis.reflector.facet.cssClass.patterns=\
+        update.*:btn-default,\
+        change.*:btn-default,\
+        maintain.*:btn-default,\
+        delete.*:btn-warning,\
+        remove.*:btn-warning
+        # this messes up the drop-downs
+        #.*:btn-primary

--- a/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
+++ b/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
@@ -308,6 +308,8 @@ isis.viewer.wicket.themes.showChooser=true
 
 
 ###############################################################################
+#
+# previously in viewer_restful.properties
 # Non-standard configuration settings.
 #
 # If enabled of the following are enabled then the viewer is deviating from the
@@ -342,3 +344,49 @@ isis.viewer.restfulobjects.objectPropertyValuesOnly=true
 #isis.viewer.restfulobjects.suppressMemberDisabledReason=true
 isis.viewer.restfulobjects.suppressMemberDisabledReason=true
 
+
+
+#################################################################################
+#
+# previously hardcoded in EstatioAppManifest
+#
+#################################################################################
+
+isis.reflector.facet.cssClassFa.patterns=\
+        new.*:fa-plus,\
+        add.*:fa-plus-square,\
+        create.*:fa-plus,\
+        update.*:fa-edit,\
+        change.*:fa-edit,\
+        maintain.*:fa-edit,\
+        remove.*:fa-minus-square,\
+        copy.*:fa-copy,\
+        move.*:fa-arrow-right,\
+        first.*:fa-star,\
+        find.*:fa-search,\
+        lookup.*:fa-search,\
+        search.*:fa-search,\
+        clear.*:fa-remove,\
+        previous.*:fa-step-backward,\
+        next.*:fa-step-forward,\
+        list.*:fa-list,\
+        all.*:fa-list,\
+        download.*:fa-download,\
+        upload.*:fa-upload,\
+        export.*:fa-exchange,\
+        import.*:fa-exchange,\
+        execute.*:fa-bolt,\
+        run.*:fa-bolt,\
+        calculate.*:fa-calculator,\
+        verify.*:fa-check-circle,\
+        refresh.*:fa-refresh,\
+        install.*:fa-wrench,\
+        stop.*:fa-stop,\
+        terminate.*:fa-stop,\
+        pause.*:fa-pause,\
+        suspend.*:fa-pause,\
+        resume.*:fa-play,\
+        renew.*:fa-repeat,\
+        assign.*:fa-hand-o-right,\
+        approve.*:fa-thumbs-o-up,\
+        decline.*:fa-thumbs-o-down

--- a/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
+++ b/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
@@ -50,7 +50,11 @@ isis.services.eventbus.implementation=guava
 
 #isis.reflector.validator.allowDeprecated=false
 
-#isis.objects.editing=false
+isis.objects.editing=false
+
+isis.services.eventbus.allowLateRegistration=true
+isis.services.injector.injectPrefix=true
+
 
 
 ################################################################################

--- a/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
+++ b/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
@@ -400,3 +400,9 @@ isis.reflector.facet.cssClass.patterns=\
         remove.*:btn-warning
         # this messes up the drop-downs
         #.*:btn-primary
+
+
+isis.reflector.facets.include=\
+    org.isisaddons.module.security.facets.TenantedAuthorizationFacetFactory,\
+    org.isisaddons.metamodel.paraname8.NamedFacetOnParameterParaname8Factory
+

--- a/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
+++ b/estatioapp/app/src/main/java/org/estatio/app/isis-non-changing.properties
@@ -406,3 +406,7 @@ isis.reflector.facets.include=\
     org.isisaddons.module.security.facets.TenantedAuthorizationFacetFactory,\
     org.isisaddons.metamodel.paraname8.NamedFacetOnParameterParaname8Factory
 
+
+isis.persistor.datanucleus.impl.datanucleus.deletionPolicy=DataNucleus
+
+

--- a/estatioapp/integtests/src/main/java/org/estatio/integtests/EstatioIntegrationTest.java
+++ b/estatioapp/integtests/src/main/java/org/estatio/integtests/EstatioIntegrationTest.java
@@ -23,8 +23,6 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
-import com.google.common.collect.Lists;
-
 import org.apache.log4j.Level;
 import org.apache.log4j.PropertyConfigurator;
 import org.junit.BeforeClass;
@@ -82,13 +80,6 @@ public abstract class EstatioIntegrationTest extends IncodeIntegrationTestAbstra
                             Util.withJavaxJdoRunInMemoryProperties(props);
                             Util.withDataNucleusProperties(props);
                             return props;
-                        }
-                        @Override
-                        public List<Class<?>> getAdditionalServices() {
-                            List<Class<?>> additionalServices = Lists.newArrayList();
-                            appendEstatioCalendarService(additionalServices);
-                            appendOptionalServicesForSecurityModule(additionalServices);
-                            return additionalServices;
                         }
                     })
                     .build()

--- a/estatioapp/integtests/src/main/java/org/estatio/integtests/EstatioIntegrationTest.java
+++ b/estatioapp/integtests/src/main/java/org/estatio/integtests/EstatioIntegrationTest.java
@@ -18,6 +18,8 @@
  */
 package org.estatio.integtests;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -65,14 +67,11 @@ public abstract class EstatioIntegrationTest extends IncodeIntegrationTestAbstra
             isft = new IsisSystemForTest.Builder()
                     .withLoggingAt(Level.WARN)
                     .with(new AuthenticationRequestNameOnly("estatio-admin"))
-                    .with(new EstatioAppManifest() {
-
-                        @Override public List<Class<?>> getModules() {
-                            final List<Class<?>> modules = super.getModules();
-                            modules.add(EstatioIntegTestFakeServicesModule.class);
-                            return modules;
-                        }
-
+                    .with(new EstatioAppManifest(
+                            Collections.emptyList(),
+                            null,
+                            Arrays.asList(EstatioIntegTestFakeServicesModule.class)
+                    ) {
                         @Override
                         public Map<String, String> getConfigurationProperties() {
                             Map<String, String> props = super.getConfigurationProperties();

--- a/estatioapp/webapp/src/main/webapp/WEB-INF/isis.properties
+++ b/estatioapp/webapp/src/main/webapp/WEB-INF/isis.properties
@@ -128,3 +128,22 @@ isis.viewer.restfulobjects.RestfulObjectsSpecEventSerializer.baseUrl=http://loca
 
 
 
+
+#################################################################################
+#
+# previously hardcoded in EstatioAppManifest
+#
+#################################################################################
+
+
+#
+# We need to use overrides where we have a dependency on a module whose entities is defined to reside
+# its own schema (eg incode modules), but where we have a PK/FK relationship to its entities.
+# In these cases, because DN (seems to) require both are in the same schema, we force the module's entity to be
+# mapped to a table in Estatio's own schema, ie 'dbo'.
+#
+# We also use overrides for certain column/property mappings, eg to reduce size of the bookmark columns where
+# these have an index on them (limited to 900 bytes).
+#
+isis.persistor.datanucleus.impl.datanucleus.Mapping=sqlserver
+

--- a/estatioapp/webapp/src/main/webapp/WEB-INF/isis.properties
+++ b/estatioapp/webapp/src/main/webapp/WEB-INF/isis.properties
@@ -30,15 +30,19 @@ org.apache.isis.viewer.restfulobjects.rendering.eventserializer.RestfulObjectsSp
 
 
 
+#
+# gmail.com
+#
+# for this to work, will need to enable 'access to less secure apps',
+# see https://support.google.com/accounts/answer/6010255.
+#
+# to avoid hardcoding passwords here, specify user and password using system properties, eg:
+# -Disis.service.email.sender.address=xxx -Disis.service.email.sender.password=yyy
+#
+#isis.service.email.sender.hostname=smtp.gmail.com
+#isis.service.email.port=587
+#isis.service.email.tls.enabled=true
 
-
-## for testing
-# consider mailtrap.io, debugmail.io, or gmail.com
-#isis.service.email.sender.address=
-#isis.service.email.sender.password=
-#isis.service.email.sender.hostname=
-#isis.service.email.port=
-#isis.service.email.tls.enabled=
 
 #isis.service.email.override.to=
 #isis.service.email.override.cc=


### PR DESCRIPTION
EstatioAppManifest now accepts fixture scripts, authMechanism and additional modules in its constructor.  Subclasses pass this stuff up.  This means that the an implementations of the AppManifest API are (for the most part) final in EstatioAppManifest, making it much easier to see how the subclasses vary that default implementation.

Also, standard properties are moved into isis-non-changing.properties, while varying properties are moved into WEB-INF/isis.properties  (respectively for both OS and ECP versions).
