### PR TITLE
Est 1801

### DIFF
--- a/estatioapp/app/src/main/java/org/estatio/module/lease/dom/invoicing/InvoiceForLease.java
+++ b/estatioapp/app/src/main/java/org/estatio/module/lease/dom/invoicing/InvoiceForLease.java
@@ -106,7 +106,7 @@ import lombok.Setter;
                 value = "SELECT " +
                         "FROM org.estatio.module.invoice.dom.Invoice " +
                         "WHERE lease == :lease " +
-                        "ORDER BY invoiceDate DESC"),
+                        "ORDER BY dueDate DESC"),
         @javax.jdo.annotations.Query(
                    name = "findByFixedAssetAndStatus", language = "JDOQL",
                 value = "SELECT " +

--- a/estatioapp/app/src/test/java/org/estatio/module/lease/integtests/lease/LeaseTermsForDeposit_IntegTest.java
+++ b/estatioapp/app/src/test/java/org/estatio/module/lease/integtests/lease/LeaseTermsForDeposit_IntegTest.java
@@ -118,8 +118,8 @@ public class LeaseTermsForDeposit_IntegTest extends LeaseModuleIntegTestAbstract
 
             // then
             assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).size()).isEqualTo(2);
-            assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).get(0).getTotalNetAmount()).isEqualTo(new BigDecimal("10000.00"));
-            assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).get(1).getTotalNetAmount()).isEqualTo(new BigDecimal("652.51"));
+            assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).get(0).getTotalNetAmount()).isEqualTo(new BigDecimal("652.51"));
+            assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).get(1).getTotalNetAmount()).isEqualTo(new BigDecimal("10000.00"));
 
             // and after approval of first invoice only the delta is invoiced
             final Invoice invoice = invoiceForLeaseRepository.findByLease(topmodelLease).get(0);
@@ -133,7 +133,7 @@ public class LeaseTermsForDeposit_IntegTest extends LeaseModuleIntegTestAbstract
 
             // then
             assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).size()).isEqualTo(2);
-            assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).get(1).getTotalNetAmount()).isEqualTo(new BigDecimal("652.51"));
+            assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).get(0).getTotalNetAmount()).isEqualTo(new BigDecimal("652.51"));
 
             // and after terminating the invoiced deposit is credited
             depositTerm = (LeaseTermForDeposit) topmodelLease.findFirstItemOfType(LeaseItemType.DEPOSIT).getTerms().first();
@@ -149,7 +149,7 @@ public class LeaseTermsForDeposit_IntegTest extends LeaseModuleIntegTestAbstract
 
             //then
             assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).size()).isEqualTo(3);
-            assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).get(2).getTotalNetAmount()).isEqualTo(new BigDecimal("-10652.51"));
+            assertThat(invoiceForLeaseRepository.findByLease(topmodelLease).get(1).getTotalNetAmount()).isEqualTo(new BigDecimal("-10652.51"));
 
         }
 

--- a/estatioapp/app/src/test/java/org/estatio/module/lease/integtests/migrations/CreateRetroInvoices_IntegTest.java
+++ b/estatioapp/app/src/test/java/org/estatio/module/lease/integtests/migrations/CreateRetroInvoices_IntegTest.java
@@ -162,7 +162,7 @@ public class CreateRetroInvoices_IntegTest extends LeaseModuleIntegTestAbstract 
             // then
             List<InvoiceForLease> invoicessAfterCreateLegacy = invoiceForLeaseRepository.findByLease(lease);
             assertThat(invoicessAfterCreateLegacy.size(), is(9));
-            Invoice invoice = invoicessAfterCreateLegacy.get(8);
+            Invoice invoice = invoicessAfterCreateLegacy.get(0);
             assertThat(invoice.getDueDate(), is(VT.ld(2014, 2, 1)));
             assertThat(invoice.getTotalGrossAmount(), is(VT.bd("-8170.01")));
 


### PR DESCRIPTION
Changes the collection orderby for invoices on leases. And fixed the integ tests behaviour to match the new ordering. 