### PR TITLE
Download jetty-maven-plugin 9.4.35.v20201120 instead of default 9.3.5.*

### DIFF
--- a/estatioapp/webapp/pom.xml
+++ b/estatioapp/webapp/pom.xml
@@ -93,6 +93,7 @@ language governing permissions and limitations under the License.
     </build>
 
     <properties>
+        <jetty-maven-plugin.version>9.4.35.v20201120</jetty-maven-plugin.version>
         <maven-war-plugin.warName>${project.parent.artifactId}</maven-war-plugin.warName>
     </properties>
 


### PR DESCRIPTION
jettywar downloads 9.3.5.* by default, this property will override
the property defined in java-mavenmixin-jettywar.

jetty-maven-plugin 9.3.5.* causes the following error:
https://user-images.githubusercontent.com/37409593/68852518-5101da80-06d8-11ea-96d7-598bd66d659d.png